### PR TITLE
[feat][#11] travel page의 추가적인 기능 구현

### DIFF
--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		D263CA2A2B05285C00B4A144 /* Network in Frameworks */ = {isa = PBXBuildFile; productRef = D263CA292B05285C00B4A144 /* Network */; };
 		D263CA2D2B052ECC00B4A144 /* TravelEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D263CA2C2B052ECC00B4A144 /* TravelEndPoint.swift */; };
 		D263CA2F2B054A0E00B4A144 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D263CA2E2B054A0E00B4A144 /* SearchResultViewController.swift */; };
+		D263CA332B06C7B300B4A144 /* SavedRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = D263CA322B06C7B300B4A144 /* SavedRoute.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,6 +50,7 @@
 		D263CA272B043C6B00B4A144 /* PinnedPlaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedPlaceManager.swift; sourceTree = "<group>"; };
 		D263CA2C2B052ECC00B4A144 /* TravelEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelEndPoint.swift; sourceTree = "<group>"; };
 		D263CA2E2B054A0E00B4A144 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
+		D263CA322B06C7B300B4A144 /* SavedRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedRoute.swift; sourceTree = "<group>"; };
 		EFE56344E8979EDA80D9E782 /* libPods-Macro.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Macro.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE963544592A2BC35C2CD604 /* Pods-Macro.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Macro.release.xcconfig"; path = "Target Support Files/Pods-Macro/Pods-Macro.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -208,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				D263CA1B2B04074D00B4A144 /* LocationDetail.swift */,
+				D263CA322B06C7B300B4A144 /* SavedRoute.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 				D263CA222B040EBE00B4A144 /* TravelViewModel.swift in Sources */,
 				D263CA132B02DD8900B4A144 /* RouteTableViewController.swift in Sources */,
 				AA46C4BC2B02304400856628 /* HomeViewController.swift in Sources */,
+				D263CA332B06C7B300B4A144 /* SavedRoute.swift in Sources */,
 				D263CA152B02ED2B00B4A144 /* RouteTableViewControllerDelegate.swift in Sources */,
 				AA46C4B82B02304400856628 /* AppDelegate.swift in Sources */,
 				D263CA202B040BAF00B4A144 /* LocationSearcher.swift in Sources */,

--- a/iOS/Macro/Macro/Scene/Travel/Entities/SavedRoute.swift
+++ b/iOS/Macro/Macro/Scene/Travel/Entities/SavedRoute.swift
@@ -1,0 +1,13 @@
+//
+//  SavedRoute.swift
+//  Macro
+//
+//  Created by 김나훈 on 11/17/23.
+//
+
+import CoreLocation
+
+struct SavedRoute {
+  var pinnedPlaces: [LocationDetail] = []
+  var routePoints: [CLLocation] = []
+}

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
@@ -65,7 +65,7 @@ final class RouteTableViewController: UITableViewController {
   }
   
   private func setupDragIndicator() {
-    let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 30))
+    let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 60))
     dragIndicator.frame = CGRect(x: (headerView.bounds.width / 2) - 20, y: 8, width: 40, height: 5)
     dragIndicator.backgroundColor = .systemGray4
     dragIndicator.layer.cornerRadius = 2.5

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
@@ -9,12 +9,17 @@ import Combine
 import UIKit
 
 final class RouteTableViewController: UITableViewController {
+  
+  // MARK: - Properties
+  
   weak var delegate: RouteTableViewControllerDelegate?
   private var routeItems: [LocationDetail] = []
   private let dragIndicator = UIView()
   private var cancellables = Set<AnyCancellable>()
   var viewModel: TravelViewModel
   private let inputSubject: PassthroughSubject<TravelViewModel.Input, Never> = .init()
+  
+  // MARK: - Life Cycles
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -23,6 +28,13 @@ final class RouteTableViewController: UITableViewController {
     tableView.isEditing = true
     bind()
   }
+  
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    updateDragIndicatorPosition()
+  }
+  
+  // MARK: - Init
   
   init(viewModel: TravelViewModel) {
     self.viewModel = viewModel
@@ -33,11 +45,8 @@ final class RouteTableViewController: UITableViewController {
     fatalError("init(coder:) has not been implemented")
   }
   
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    updateDragIndicatorPosition()
-  }
-
+  // MARK: - Bind
+  
   private func bind() {
     let outputSubject = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
     
@@ -48,8 +57,9 @@ final class RouteTableViewController: UITableViewController {
       default: break
       }
     }.store(in: &cancellables)
-    
   }
+  
+  // MARK: - Methods
   
   private func updatePinnedPlaces(_ places: [LocationDetail]) {
     self.routeItems = places
@@ -68,7 +78,6 @@ final class RouteTableViewController: UITableViewController {
     
     headerView.addSubview(dragIndicator)
     tableView.tableHeaderView = headerView
-    
   }
   
   @objc private func handleDragIndicatorPan(_ gesture: UIPanGestureRecognizer) {
@@ -80,7 +89,10 @@ final class RouteTableViewController: UITableViewController {
   private func updateDragIndicatorPosition() {
     dragIndicator.center.x = tableView.tableHeaderView?.bounds.midX ?? 0
   }
-  
+}
+
+// MARK: - TableView
+extension RouteTableViewController {
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return routeItems.count
   }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
@@ -51,7 +51,7 @@ final class RouteTableViewController: UITableViewController {
     
     outputSubject.receive(on: RunLoop.main).sink { [weak self] output in
       switch output {
-      case let .updatePinnedPlaces(locationDetails):
+      case let .updatePinnedPlacesTableView(locationDetails):
         self?.updatePinnedPlaces(locationDetails)
       default: break
       }
@@ -106,13 +106,14 @@ extension RouteTableViewController {
   }
   
   override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-      viewModel.movePinnedPlace(from: sourceIndexPath.row, to: destinationIndexPath.row)
+    viewModel.movePinnedPlace(from: sourceIndexPath.row, to: destinationIndexPath.row)
   }
-
+  
   override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-      if editingStyle == .delete {
-          viewModel.removePinnedPlace(at: indexPath.row)
-          tableView.deleteRows(at: [indexPath], with: .fade)
-      }
+    if editingStyle == .delete {
+      let locationDetail = viewModel.savedRoute.pinnedPlaces[indexPath.row]
+      viewModel.removePinnedPlace(locationDetail)
+      tableView.deleteRows(at: [indexPath], with: .fade)
+    }
   }
 }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/RouteTableViewController.swift
@@ -13,7 +13,6 @@ final class RouteTableViewController: UITableViewController {
   // MARK: - Properties
   
   weak var delegate: RouteTableViewControllerDelegate?
-  private var routeItems: [LocationDetail] = []
   private let dragIndicator = UIView()
   private var cancellables = Set<AnyCancellable>()
   var viewModel: TravelViewModel
@@ -62,7 +61,6 @@ final class RouteTableViewController: UITableViewController {
   // MARK: - Methods
   
   private func updatePinnedPlaces(_ places: [LocationDetail]) {
-    self.routeItems = places
     self.tableView.reloadData()
   }
   
@@ -94,12 +92,12 @@ final class RouteTableViewController: UITableViewController {
 // MARK: - TableView
 extension RouteTableViewController {
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return routeItems.count
+    return viewModel.savedRoute.pinnedPlaces.count
   }
   
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-    cell.textLabel?.text = routeItems[indexPath.row].title
+    cell.textLabel?.text = viewModel.savedRoute.pinnedPlaces[indexPath.row].title
     return cell
   }
   
@@ -108,14 +106,13 @@ extension RouteTableViewController {
   }
   
   override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-    let movedItem = routeItems.remove(at: sourceIndexPath.row)
-    routeItems.insert(movedItem, at: destinationIndexPath.row)
+      viewModel.movePinnedPlace(from: sourceIndexPath.row, to: destinationIndexPath.row)
   }
-  
+
   override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-    if editingStyle == .delete {
-      routeItems.remove(at: indexPath.row)
-      tableView.deleteRows(at: [indexPath], with: .fade)
-    }
+      if editingStyle == .delete {
+          viewModel.removePinnedPlace(at: indexPath.row)
+          tableView.deleteRows(at: [indexPath], with: .fade)
+      }
   }
 }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/SearchResultViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/SearchResultViewController.swift
@@ -58,23 +58,26 @@ final class SearchResultViewController: UIViewController, UITableViewDataSource,
   // MARK: - Bind
   
   private func bind() {
-      viewModel.transform(with: inputSubject.eraseToAnyPublisher())
-        .sink { [weak self] output in
-            switch output {
-            case .updateSearchResult:
-                self?.tableView.reloadData()
-            default:
-                break
-            }
+    viewModel.transform(with: inputSubject.eraseToAnyPublisher())
+      .sink { [weak self] output in
+        switch output {
+        case .updateSearchResult:
+          self?.tableView.reloadData()
+        default:
+          break
         }
-        .store(in: &cancellables)
+      }
+      .store(in: &cancellables)
   }
   
   // MARK: - Methods
   
   @objc func pinLocation(_ sender: UIButton) {
-    let locationDetail = viewModel.searchedResult[sender.tag]
-    inputSubject.send(.addPinnedLocation(locationDetail))
+    let location = viewModel.searchedResult[sender.tag]
+    viewModel.togglePinnedPlaces(location)
+    let isPinnedNow = viewModel.isPinned(location)
+    let pinImage = isPinnedNow ? UIImage.appImage(.pinFill) : UIImage.appImage(.pin)
+    sender.setImage(pinImage, for: .normal)
   }
 }
 
@@ -90,7 +93,8 @@ extension SearchResultViewController {
     let locationDetail = viewModel.searchedResult[indexPath.row]
     cell.textLabel?.text = locationDetail.title
     let pinButton = UIButton(type: .custom)
-    pinButton.setImage(UIImage(systemName: "pin"), for: .normal)
+    let pinImage = viewModel.isPinned(locationDetail) ? UIImage.appImage(.pinFill) : UIImage.appImage(.pin)
+    pinButton.setImage(pinImage, for: .normal)
     pinButton.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
     pinButton.addTarget(self, action: #selector(pinLocation(_:)), for: .touchUpInside)
     cell.accessoryView = pinButton

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/SearchResultViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/SearchResultViewController.swift
@@ -9,11 +9,25 @@ import Combine
 import UIKit
 
 final class SearchResultViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+  
+  // MARK: - Properties
+  
   private var locationDetails: [LocationDetail]
   private var tableView: UITableView!
   private let viewModel: TravelViewModel
   private let inputSubject: PassthroughSubject<TravelViewModel.Input, Never> = .init()
   private var cancellables = Set<AnyCancellable>()
+  
+  // MARK: - Life Cycles
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+    setupTableView()
+    bind()
+  }
+  
+  // MARK: - Init
   
   init(locationDetails: [LocationDetail], viewModel: TravelViewModel) {
     self.locationDetails = locationDetails
@@ -25,20 +39,7 @@ final class SearchResultViewController: UIViewController, UITableViewDataSource,
     fatalError("init(coder:) has not been implemented")
   }
   
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = .systemBackground
-    setupTableView()
-    bind()
-  }
-  
-  private func bind() {
-    viewModel.transform(with: inputSubject.eraseToAnyPublisher())
-      .sink { [weak self] output in
-        // TODO: implements 
-      }
-      .store(in: &cancellables)
-  }
+  // MARK: - UI Settings
   
   private func setupTableView() {
     tableView = UITableView()
@@ -56,6 +57,27 @@ final class SearchResultViewController: UIViewController, UITableViewDataSource,
     ])
   }
   
+  // MARK: - Bind
+  
+  private func bind() {
+    viewModel.transform(with: inputSubject.eraseToAnyPublisher())
+      .sink { _ in
+        // TODO: implements 
+      }
+      .store(in: &cancellables)
+  }
+  
+  // MARK: - Methods
+  
+  @objc func pinLocation(_ sender: UIButton) {
+    let locationDetail = locationDetails[sender.tag]
+    inputSubject.send(.addPinnedLocation(locationDetail))
+  }
+}
+
+// MARK: - TableView
+
+extension SearchResultViewController {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return locationDetails.count
   }
@@ -76,10 +98,5 @@ final class SearchResultViewController: UIViewController, UITableViewDataSource,
   
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     // TODO: 테이블 뷰가 눌리면, 경로추천 segment 실행
-  }
-  
-  @objc func pinLocation(_ sender: UIButton) {
-    let locationDetail = locationDetails[sender.tag]
-    inputSubject.send(.addPinnedLocation(locationDetail))
   }
 }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
@@ -196,7 +196,7 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
   }
   
   private func getSearchResult(_ locationDetails: [LocationDetail]) {
-    let searchResultVC = SearchResultViewController(locationDetails: locationDetails, viewModel: viewModel)
+    let searchResultVC = SearchResultViewController(viewModel: viewModel)
     navigationController?.pushViewController(searchResultVC, animated: true)
   }
   

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
@@ -155,6 +155,8 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
         self?.removeMarker(for: locationDetail)
       case let .updateRoute(location):
         self?.updateMapWithLocation(location)
+      case let .updateMarkers(pinnedPlaces):
+        self?.updateMarkers(pinnedPlaces)
       default: break
       }
     }.store(in: &cancellables)
@@ -200,16 +202,28 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
   }
   
   private func updateMarkers() {
-      markers.values.forEach { $0.mapView = nil }
-      markers.removeAll()
-
-      for (index, place) in viewModel.savedRoute.pinnedPlaces.enumerated() {
-          let marker = NMFMarker()
-          marker.position = NMGLatLng(lat: place.mapy, lng: place.mapx)
-          marker.captionText = "\(index + 1)"
-          marker.mapView = mapView
-          markers[place.title] = marker
-      }
+    markers.values.forEach { $0.mapView = nil }
+    markers.removeAll()
+    
+    for (index, place) in viewModel.savedRoute.pinnedPlaces.enumerated() {
+      let marker = NMFMarker()
+      marker.position = NMGLatLng(lat: place.mapy, lng: place.mapx)
+      marker.captionText = "\(index + 1)"
+      marker.mapView = mapView
+      markers[place.title] = marker
+    }
+  }
+  private func updateMarkers(_ pinnedPlaces: [LocationDetail]) {
+    markers.values.forEach { $0.mapView = nil }
+    markers.removeAll()
+    
+    for (index, place) in pinnedPlaces.enumerated() {
+      let marker = NMFMarker()
+      marker.position = NMGLatLng(lat: place.mapy, lng: place.mapx)
+      marker.captionText = "\(index + 1)"
+      marker.mapView = mapView
+      markers[place.title] = marker
+    }
   }
   
   private func updateTravelButton() {

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
@@ -69,6 +69,8 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
     updateTravelButton()
   }
   
+  private var markers: [String: NMFMarker] = [:]
+  
   override func viewWillLayoutSubviews() {
     view.bringSubviewToFront(travelButton)
   }
@@ -143,8 +145,8 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
         self?.tempMethod()
       case let .updateSearchResult(locationDetails):
         self?.getSearchResult(locationDetails)
-      case let .addPinnedPlaceInMap(mapx, mapy):
-        self?.addPinnedPlace(mapx: mapx, mapy: mapy)
+      case let .updatePinnedPlaceInMap(pinnedPlaces):
+        self?.updateMarkers(with: pinnedPlaces)
       case let .updateRoute(location):
         self?.updateMapWithLocation(location)
       default: break
@@ -189,10 +191,17 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
   private func tempMethod() {
   }
   
-  private func addPinnedPlace(mapx: Double, mapy: Double) {
-    let marker = NMFMarker()
-    marker.position = NMGLatLng(lat: mapy, lng: mapx)
-    marker.mapView = mapView
+  private func updateMarkers(with places: [LocationDetail]) {
+    markers.values.forEach { $0.mapView = nil }
+    markers.removeAll()
+    // 새로운 마커 생성 및 추가
+    for place in places {
+      let marker = NMFMarker()
+      marker.position = NMGLatLng(lat: place.mapy, lng: place.mapx)
+      marker.mapView = mapView
+      markers[place.title] = marker
+    }
+    
   }
   
   private func getSearchResult(_ locationDetails: [LocationDetail]) {

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
@@ -145,8 +145,10 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
         self?.tempMethod()
       case let .updateSearchResult(locationDetails):
         self?.getSearchResult(locationDetails)
-      case let .updatePinnedPlaceInMap(pinnedPlaces):
-        self?.updateMarkers(with: pinnedPlaces)
+      case let .addPinnedPlaceInMap(locationDetail):
+        self?.addMarker(for: locationDetail)
+      case let .removePinnedPlaceInMap(locationDetail):
+        self?.removeMarker(for: locationDetail)
       case let .updateRoute(location):
         self?.updateMapWithLocation(location)
       default: break
@@ -162,6 +164,25 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
     let coords = routePoints.map { NMGLatLng(lat: $0.coordinate.latitude, lng: $0.coordinate.longitude) }
     routeOverlay = NMFPolylineOverlay(coords)
     routeOverlay?.mapView = mapView
+  }
+  
+  private func addMarker(for locationDetail: LocationDetail) {
+    let marker = NMFMarker()
+    let position = NMGLatLng(lat: locationDetail.mapy, lng: locationDetail.mapx)
+    marker.position = position
+    marker.mapView = mapView
+    markers[locationDetail.title] = marker
+    
+    let cameraUpdate = NMFCameraUpdate(scrollTo: position)
+    cameraUpdate.animation = .easeIn
+    mapView.moveCamera(cameraUpdate)
+  }
+  
+  private func removeMarker(for locationDetail: LocationDetail) {
+    if let marker = markers[locationDetail.title] {
+      marker.mapView = nil
+      markers.removeValue(forKey: locationDetail.title)
+    }
   }
   
   private func updateTravelButton() {
@@ -189,19 +210,6 @@ final class TravelViewController: UIViewController, RouteTableViewControllerDele
   }
   
   private func tempMethod() {
-  }
-  
-  private func updateMarkers(with places: [LocationDetail]) {
-    markers.values.forEach { $0.mapView = nil }
-    markers.removeAll()
-    // 새로운 마커 생성 및 추가
-    for place in places {
-      let marker = NMFMarker()
-      marker.position = NMGLatLng(lat: place.mapy, lng: place.mapx)
-      marker.mapView = mapView
-      markers[place.title] = marker
-    }
-    
   }
   
   private func getSearchResult(_ locationDetails: [LocationDetail]) {

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
 
 final class TravelViewModel: ViewModelProtocol {
   
-  // MARK: Input
+  // MARK: - Input
   
   enum Input {
     case startTravel
@@ -22,7 +22,7 @@ final class TravelViewModel: ViewModelProtocol {
     case addPinnedLocation(LocationDetail)
   }
   
-  // MARK: Output
+  // MARK: - Output
   
   enum Output {
     case exchangeCell
@@ -33,7 +33,7 @@ final class TravelViewModel: ViewModelProtocol {
     case updateRoute([CLLocation])
   }
   
-  // MARK: Properties
+  // MARK: - Properties
   
   private let outputSubject = PassthroughSubject<Output, Never>()
   private let routeRecorder: RouteRecordUseCase
@@ -42,7 +42,7 @@ final class TravelViewModel: ViewModelProtocol {
   private var cancellables = Set<AnyCancellable>()
   private var routePoints: [CLLocation] = []
   
-  // MARK: Initialization
+  // MARK: - Init
   
   init(routeRecorder: RouteRecordUseCase, locationSearcher: LocationSearchUseCase, pinnedPlaceManager: PinnedPlaceManageUseCase) {
     self.routeRecorder = routeRecorder
@@ -50,7 +50,7 @@ final class TravelViewModel: ViewModelProtocol {
     self.pinnedPlaceManager = pinnedPlaceManager
   }
   
-  // MARK: Methods
+  // MARK: - Methods
   
   func transform(with input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
     input.sink { [weak self] input in
@@ -105,7 +105,6 @@ final class TravelViewModel: ViewModelProtocol {
     } receiveValue: { [weak self] response in
       self?.outputSubject.send(.updateSearchResult(response))
     }.store(in: &cancellables)
-    
   }
   
 }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -40,7 +40,7 @@ final class TravelViewModel: ViewModelProtocol {
   private let locationSearcher: LocationSearchUseCase
   private let pinnedPlaceManager: PinnedPlaceManageUseCase
   private var cancellables = Set<AnyCancellable>()
-  private var routePoints: [CLLocation] = []
+  private var savedRoute: SavedRoute = SavedRoute()
   
   // MARK: - Init
   
@@ -87,8 +87,8 @@ final class TravelViewModel: ViewModelProtocol {
     routeRecorder.startRecording()
     routeRecorder.locationPublisher
       .sink { [weak self] location in
-        self?.routePoints.append(location)
-        self?.outputSubject.send(.updateRoute(self?.routePoints ?? []))
+        self?.savedRoute.routePoints.append(location)
+        self?.outputSubject.send(.updateRoute(self?.savedRoute.routePoints ?? []))
       }
       .store(in: &cancellables)
   }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -78,8 +78,10 @@ final class TravelViewModel: ViewModelProtocol {
   }
   
   private func addPinnedLocation(locationDetail: LocationDetail) {
-    pinnedPlaceManager.addPinnedLocation(locationDetail: locationDetail)
-    outputSubject.send(.updatePinnedPlaces(pinnedPlaceManager.getCurrendPinnedPlaces()))
+    
+    let newPinnedPlaces = pinnedPlaceManager.addPinnedLocation(locationDetail: locationDetail, to: savedRoute.pinnedPlaces)
+    savedRoute.pinnedPlaces = newPinnedPlaces
+    outputSubject.send(.updatePinnedPlaces(newPinnedPlaces))
     outputSubject.send(.addPinnedPlaceInMap(locationDetail.mapx, locationDetail.mapy))
   }
   

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -40,7 +40,8 @@ final class TravelViewModel: ViewModelProtocol {
   private let locationSearcher: LocationSearchUseCase
   private let pinnedPlaceManager: PinnedPlaceManageUseCase
   private var cancellables = Set<AnyCancellable>()
-  private var savedRoute: SavedRoute = SavedRoute()
+  private (set) var savedRoute: SavedRoute = SavedRoute()
+  private (set) var searchedResult: [LocationDetail] = []
   
   // MARK: - Init
   
@@ -105,6 +106,7 @@ final class TravelViewModel: ViewModelProtocol {
         print(error)
       }
     } receiveValue: { [weak self] response in
+      self?.searchedResult = response
       self?.outputSubject.send(.updateSearchResult(response))
     }.store(in: &cancellables)
   }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -32,6 +32,7 @@ final class TravelViewModel: ViewModelProtocol {
     case addPinnedPlaceInMap(LocationDetail)
     case removePinnedPlaceInMap(LocationDetail)
     case updateRoute([CLLocation])
+    case updateMarkers([LocationDetail])
   }
   
   // MARK: - Properties
@@ -115,6 +116,7 @@ final class TravelViewModel: ViewModelProtocol {
   func movePinnedPlace(from sourceIndex: Int, to destinationIndex: Int) {
     savedRoute.pinnedPlaces = pinnedPlaceManager.movePinnedPlace(from: sourceIndex, to: destinationIndex, in: savedRoute.pinnedPlaces)
     outputSubject.send(.updatePinnedPlacesTableView(savedRoute.pinnedPlaces))
+    outputSubject.send(.updateMarkers(savedRoute.pinnedPlaces))
   }
   
   func addPinnedPlace(_ locationDetail: LocationDetail) {

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -111,4 +111,13 @@ final class TravelViewModel: ViewModelProtocol {
     }.store(in: &cancellables)
   }
   
+   func movePinnedPlace(from sourceIndex: Int, to destinationIndex: Int) {
+      let movedItem = savedRoute.pinnedPlaces.remove(at: sourceIndex)
+      savedRoute.pinnedPlaces.insert(movedItem, at: destinationIndex)
+  }
+
+  func removePinnedPlace(at index: Int) {
+      savedRoute.pinnedPlaces.remove(at: index)
+  }
+  
 }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -29,7 +29,8 @@ final class TravelViewModel: ViewModelProtocol {
     case exchangeLocation
     case updateSearchResult([LocationDetail])
     case updatePinnedPlacesTableView([LocationDetail])
-    case updatePinnedPlaceInMap([LocationDetail])
+    case addPinnedPlaceInMap(LocationDetail)
+    case removePinnedPlaceInMap(LocationDetail)
     case updateRoute([CLLocation])
   }
   
@@ -79,7 +80,7 @@ final class TravelViewModel: ViewModelProtocol {
   }
   
   func togglePinnedPlaces(_ locationDetail: LocationDetail) {
-    if let index = savedRoute.pinnedPlaces.firstIndex(where: { $0.title == locationDetail.title }) {
+    if savedRoute.pinnedPlaces.contains(where: { $0.title == locationDetail.title }) {
       removePinnedPlace(locationDetail)
     } else {
       addPinnedPlace(locationDetail)
@@ -112,21 +113,21 @@ final class TravelViewModel: ViewModelProtocol {
   }
   
   func movePinnedPlace(from sourceIndex: Int, to destinationIndex: Int) {
-         savedRoute.pinnedPlaces = pinnedPlaceManager.movePinnedPlace(from: sourceIndex, to: destinationIndex, in: savedRoute.pinnedPlaces)
-         outputSubject.send(.updatePinnedPlacesTableView(savedRoute.pinnedPlaces))
-     }
+    savedRoute.pinnedPlaces = pinnedPlaceManager.movePinnedPlace(from: sourceIndex, to: destinationIndex, in: savedRoute.pinnedPlaces)
+    outputSubject.send(.updatePinnedPlacesTableView(savedRoute.pinnedPlaces))
+  }
   
   func addPinnedPlace(_ locationDetail: LocationDetail) {
     savedRoute.pinnedPlaces.append(locationDetail)
     outputSubject.send(.updatePinnedPlacesTableView(savedRoute.pinnedPlaces))
-    outputSubject.send(.updatePinnedPlaceInMap(savedRoute.pinnedPlaces))
+    outputSubject.send(.addPinnedPlaceInMap(locationDetail))
   }
   
   func removePinnedPlace(_ locationDetail: LocationDetail) {
     if let index = savedRoute.pinnedPlaces.firstIndex(where: { $0.title == locationDetail.title }) {
       savedRoute.pinnedPlaces.remove(at: index)
       outputSubject.send(.updatePinnedPlacesTableView(savedRoute.pinnedPlaces))
-      outputSubject.send(.updatePinnedPlaceInMap(savedRoute.pinnedPlaces))
+      outputSubject.send(.removePinnedPlaceInMap(locationDetail))
     }
   }
   

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -112,9 +112,9 @@ final class TravelViewModel: ViewModelProtocol {
   }
   
   func movePinnedPlace(from sourceIndex: Int, to destinationIndex: Int) {
-    let movedItem = savedRoute.pinnedPlaces.remove(at: sourceIndex)
-    savedRoute.pinnedPlaces.insert(movedItem, at: destinationIndex)
-  }
+         savedRoute.pinnedPlaces = pinnedPlaceManager.movePinnedPlace(from: sourceIndex, to: destinationIndex, in: savedRoute.pinnedPlaces)
+         outputSubject.send(.updatePinnedPlacesTableView(savedRoute.pinnedPlaces))
+     }
   
   func addPinnedPlace(_ locationDetail: LocationDetail) {
     savedRoute.pinnedPlaces.append(locationDetail)

--- a/iOS/Macro/Macro/Scene/Travel/UseCases/LocationSearcher.swift
+++ b/iOS/Macro/Macro/Scene/Travel/UseCases/LocationSearcher.swift
@@ -15,11 +15,17 @@ protocol LocationSearchUseCase {
 
 final class LocationSearcher: LocationSearchUseCase {
 
+  // MARK: - Properties
+  
   private let provider: Requestable
 
+  // MARK: - Init
+  
   init(provider: Requestable) {
     self.provider = provider
   }
+  
+  // MARK: - Methods
   
   func searchLocation(query: String) -> AnyPublisher<[LocationDetail], Network.NetworkError> {
     return provider.request(TravelEndPoint.search(query))

--- a/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
+++ b/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
@@ -11,14 +11,13 @@ import Network
 /// 사용자가 핀으로 고정한 장소를 관리하는 UseCase
 protocol PinnedPlaceManageUseCase {
   
-  /// 핀으로 지정한 장소를 지우는 함수
-  func deleteRoute()
-  
   /// 핀으로 지정한 장소의 순서를 바꾸는 함수
   func exchangeRoute()
   
   /// 핀으로 특정 장소를 추가하는 함수
-  func addPinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail] 
+  func addPinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail]
+  
+  func deletePinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail]
   
 }
 
@@ -36,17 +35,21 @@ final class PinnedPlaceManager: PinnedPlaceManageUseCase {
   
   // MARK: Methods
   
-  func deleteRoute() {
-    // TODO: complete method
-  }
-  
   func exchangeRoute() {
     // TODO: complete method
   }
   
   func addPinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail] {
-    var newLocationDetail = places
-    newLocationDetail.append(locationDetail)
-    return newLocationDetail
+    var newPlaces = places
+    newPlaces.append(locationDetail)
+    return newPlaces
+  }
+  
+  func deletePinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail] {
+    var newPlaces = places
+    if let index = newPlaces.firstIndex(where: { $0.title == locationDetail.title }) {
+      newPlaces.remove(at: index)
+    }
+    return newPlaces
   }
 }

--- a/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
+++ b/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
@@ -18,10 +18,8 @@ protocol PinnedPlaceManageUseCase {
   func exchangeRoute()
   
   /// 핀으로 특정 장소를 추가하는 함수
-  func addPinnedLocation(locationDetail: LocationDetail)
+  func addPinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail] 
   
-  /// 현재 핀으로 추가된 장소들의 정보를 얻는 함수
-  func getCurrendPinnedPlaces() -> [LocationDetail]
 }
 
 final class PinnedPlaceManager: PinnedPlaceManageUseCase {
@@ -29,7 +27,6 @@ final class PinnedPlaceManager: PinnedPlaceManageUseCase {
   // MARK: Properties
   
   private let provider: Requestable
-  private var pinnedPlace: [LocationDetail] = []
   
   // MARK: Init
   
@@ -47,12 +44,9 @@ final class PinnedPlaceManager: PinnedPlaceManageUseCase {
     // TODO: complete method
   }
   
-  func getCurrendPinnedPlaces() -> [LocationDetail] {
-    return pinnedPlace
-  }
-  
-  func addPinnedLocation(locationDetail: LocationDetail) {
-    pinnedPlace.append(locationDetail)
-    print(pinnedPlace.count)
+  func addPinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail] {
+    var newLocationDetail = places
+    newLocationDetail.append(locationDetail)
+    return newLocationDetail
   }
 }

--- a/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
+++ b/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
@@ -11,15 +11,13 @@ import Network
 /// 사용자가 핀으로 고정한 장소를 관리하는 UseCase
 protocol PinnedPlaceManageUseCase {
   
-  /// 핀으로 지정한 장소의 순서를 바꾸는 함수
-  func exchangeRoute()
-  
   /// 핀으로 특정 장소를 추가하는 함수
   func addPinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail]
   
   func deletePinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail]
   
-}
+  func movePinnedPlace(from sourceIndex: Int, to destinationIndex: Int, in places: [LocationDetail]) -> [LocationDetail]
+ }
 
 final class PinnedPlaceManager: PinnedPlaceManageUseCase {
   
@@ -35,10 +33,6 @@ final class PinnedPlaceManager: PinnedPlaceManageUseCase {
   
   // MARK: Methods
   
-  func exchangeRoute() {
-    // TODO: complete method
-  }
-  
   func addPinnedLocation(locationDetail: LocationDetail, to places: [LocationDetail]) -> [LocationDetail] {
     var newPlaces = places
     newPlaces.append(locationDetail)
@@ -51,5 +45,12 @@ final class PinnedPlaceManager: PinnedPlaceManageUseCase {
       newPlaces.remove(at: index)
     }
     return newPlaces
+  }
+  
+  func movePinnedPlace(from sourceIndex: Int, to destinationIndex: Int, in places: [LocationDetail]) -> [LocationDetail] {
+    var updatedPlaces = places
+           let movedItem = updatedPlaces.remove(at: sourceIndex)
+           updatedPlaces.insert(movedItem, at: destinationIndex)
+           return updatedPlaces
   }
 }

--- a/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
+++ b/iOS/Macro/Macro/Scene/Travel/UseCases/PinnedPlaceManager.swift
@@ -26,12 +26,18 @@ protocol PinnedPlaceManageUseCase {
 
 final class PinnedPlaceManager: PinnedPlaceManageUseCase {
   
+  // MARK: Properties
+  
   private let provider: Requestable
   private var pinnedPlace: [LocationDetail] = []
+  
+  // MARK: Init
   
   init(provider: Requestable) {
     self.provider = provider
   }
+  
+  // MARK: Methods
   
   func deleteRoute() {
     // TODO: complete method

--- a/iOS/Macro/Macro/Scene/Travel/UseCases/RouteRecorder.swift
+++ b/iOS/Macro/Macro/Scene/Travel/UseCases/RouteRecorder.swift
@@ -20,17 +20,23 @@ protocol RouteRecordUseCase {
 
 final class RouteRecorder: NSObject, RouteRecordUseCase, CLLocationManagerDelegate {
   
+  // MARK: - Properties
+  
   private let locationManager = CLLocationManager()
   var locationPublisher = PassthroughSubject<CLLocation, Never>()
   private let provider: Requestable
   private var locationUpdateTimer: Timer?
   private let updateInterval: TimeInterval = 3
   
+  // MARK: - Init
+  
   init(provider: Requestable) {
     self.provider = provider
     super.init()
     configureLocationManager()
   }
+  
+  // MARK: - Methods
   
   private func configureLocationManager() {
     locationManager.delegate = self

--- a/iOS/MacroDesignSystem/Sources/Network/APIProvider.swift
+++ b/iOS/MacroDesignSystem/Sources/Network/APIProvider.swift
@@ -11,18 +11,18 @@ import Foundation
 /// API 요청을 하는 Provider 입니다.
 public final class APIProvider: Requestable {
   
-  // MARK: Properties
+  // MARK: - Properties
   
   /// HTTP 요청을 수행하기 위한 Session
   private let session: Session
   
-  // MARK: Initialization
+  // MARK: Init
   
   public init(session: Session) {
     self.session = session
   }
   
-  // MARK: Method
+  // MARK: Methods
   
   public func request<Target, Model>(_ target: Target) -> AnyPublisher<Model, NetworkError> where Target : EndPoint, Model: Decodable {
     guard let request = try? target.asURLRequest()


### PR DESCRIPTION
## 개요 📖

여행 경로를 기록하는 페이지에서, 추가적인 구현이 필요

## 설명 📄

travel을 하는 페이지의 상세 기능 구현
1. pin 처리 할 시, pin.fill과 pin으로 표시
2. 처음 앱 실행 시 현재 위치로 조정됨
3. 새로 pin 처리할 시, 해당 장소로 카메라가 이동됨
4. Pin 처리할 시, 해당 좌표에 숫자가 표시 됨
5. 추가, 삭제, 위치 변경 등을 해도 마커들이 해당 작업에 맞게 수정 됨


## 고민거리 🤔 (Optional) - 의견 받고싶은 부분 있으면 적어두기

핀 처리한 장소, 내 실제 경로는 ViewModel에서 관리하고 있으나, 그것들을 가공처리하는 것은 UseCase에서 이루어 지는 것이 고민입니다.
결국 함수형 프로그래밍을 하는 것같은 느낌이 들었는데, 원본 배열,  추가할 element를 넘겨주어서 그것을 추가한 것을 리턴 받는 형식인데, 
이게 Clean Architecture 에 맞는 건가 .. ? 하는 생각이 들었던 것 같습니다.

## 스크린샷 📷 (Optional) - 스크린샷이 없으면 제거


### 여행 경로 기록 & 중지.

![KakaoTalk_Photo_2023-11-17-11-01-59](https://github.com/boostcampwm2023/iOS03-Macro/assets/118811606/0a3db86c-4abb-421b-b038-24fa3dc23e20)

### 앱을 처음 실행할 시 내 현재 위치로 카메라 이동

https://github.com/boostcampwm2023/iOS03-Macro/assets/118811606/6c90c8c9-0f2c-47f8-857e-7702502fb220


### pin으로 장소 추가할시 카메라 이동 & pin.fill로 이미지 변경

https://github.com/boostcampwm2023/iOS03-Macro/assets/118811606/49bd36f6-f5e4-47c6-97dc-dc2628d6034e

### 장소의 순서를 옮기거나, 삭제할시, map의 마커에 반영 됨

https://github.com/boostcampwm2023/iOS03-Macro/assets/118811606/53766837-0cf8-49e6-b10d-6ca1434c3ada



공통 체크 리스트
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 작업에 맞는 label을 추가했는지 확인
- [x] 컨벤션 지켰는지 확인

iOS 체크 리스트
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 15
  - [x] iPhone 15 Pro Max


