### PR TITLE
[Improve] #25 naver api to kakao api

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -21,5 +21,13 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
+    'no-unuserd-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'warn',
   },
 };

--- a/server/src/map/map.kakao.controller.ts
+++ b/server/src/map/map.kakao.controller.ts
@@ -1,0 +1,30 @@
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { KakaoMapSearchResponse } from './map.kakao.search.response.dto';
+import { KakaoMapService } from './map.kakao.service';
+import { Controller, Get, Query } from '@nestjs/common';
+import { Public } from 'src/auth/auth.decorators';
+
+@Controller('map/v2')
+export class KaKaoMapController {
+  constructor(private readonly kakaoMapService: KakaoMapService) {}
+
+  @ApiOperation({ description: '주소나 이름에 따라 위치를 검색합니다.' })
+  @ApiResponse({ type: [KakaoMapSearchResponse] })
+  @Public()
+  @Get('searchByAccuracy')
+  async searchByAccuracy(@Query('keyword') keyword: string) {
+    return await this.kakaoMapService.kakaoSearchByAccuracy(keyword);
+  }
+
+  @ApiOperation({ description: '주소나 이름에 따라 위치를 검색합니다.' })
+  @ApiResponse({ type: [KakaoMapSearchResponse] })
+  @Public()
+  @Get('earchByDistance')
+  async searchByDistance(
+    @Query('keyword') keyword: string,
+    @Query('x') x: number,
+    @Query('y') y: number,
+  ) {
+    return await this.kakaoMapService.kakaoSearchByDistance(keyword, x, y);
+  }
+}

--- a/server/src/map/map.kakao.search.response.dto.ts
+++ b/server/src/map/map.kakao.search.response.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNumber,
+  IsOptional,
+  IsPhoneNumber,
+  IsString,
+  IsUrl,
+} from 'class-validator';
+
+export class KakaoMapSearchResponse {
+  @ApiProperty({ description: '업체/기관 이름' })
+  @IsString()
+  place_name: string;
+
+  @ApiProperty({ description: '매장Id' })
+  @IsString()
+  id: number;
+
+  @ApiProperty({ description: '링크' })
+  @IsUrl()
+  @IsOptional()
+  place_url?: string;
+
+  @ApiProperty({ description: '카테고리 그룹' })
+  @IsString()
+  category_group_name: string;
+
+  @ApiProperty({ description: '카테고리' })
+  @IsString()
+  category_name: string;
+
+  @ApiProperty({ description: '전화번호' })
+  @IsPhoneNumber('KR')
+  @IsOptional()
+  phone: string;
+
+  @ApiProperty({ description: '지번 주소' })
+  @IsString()
+  address_name: string;
+
+  @ApiProperty({ description: '도로명 주소' })
+  @IsString()
+  road_address_name: string;
+
+  @ApiProperty({ description: 'x좌표' })
+  @IsNumber()
+  x: number;
+
+  @ApiProperty({ description: 'y좌표' })
+  @IsNumber()
+  y: number;
+
+  @ApiProperty({ description: '거리' })
+  @IsNumber()
+  @IsOptional()
+  distance: number;
+}

--- a/server/src/map/map.kakao.service.ts
+++ b/server/src/map/map.kakao.service.ts
@@ -1,0 +1,61 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { plainToInstance } from 'class-transformer';
+import { KakaoMapSearchResponse } from './map.kakao.search.response.dto';
+import { AxiosResponse } from 'axios';
+import { map } from 'rxjs';
+
+const pagenum = 1;
+const sizenum = 15;
+
+@Injectable()
+export class KakaoMapService {
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async kakaoSearchByAccuracy(keyword: string) {
+    return this.httpService
+      .get(
+        this.configService.get('kakao.search.url') +
+          encodeURI(
+            `?page=${pagenum}&size=${sizenum}&sort=accuracy&query=${keyword}`,
+          ),
+        {
+          headers: this.configService.get('kakao.search.headers'),
+        },
+      )
+      .pipe(
+        map(({ data }: AxiosResponse) => {
+          return plainToInstance(
+            KakaoMapSearchResponse,
+            data?.documents as any[],
+          );
+        }),
+      );
+  }
+
+  async kakaoSearchByDistance(keyword: string, x: number, y: number) {
+    return this.httpService
+      .get(
+        this.configService.get('kakao.search.url') +
+          encodeURI(
+            `?page=${pagenum}&size=${sizenum}&sort=distance
+          &query=${keyword}&x=${x}&y=${y}`,
+          ),
+        {
+          headers: this.configService.get('kakao.search.headers'),
+        },
+      )
+      .pipe(
+        map(({ data }: AxiosResponse) => {
+          return plainToInstance(
+            KakaoMapSearchResponse,
+            data?.documents as any[],
+          );
+        }),
+      );
+  }
+}

--- a/server/src/map/map.module.ts
+++ b/server/src/map/map.module.ts
@@ -1,10 +1,14 @@
 import { Global, Module } from '@nestjs/common';
-import { MapController } from './map.controller';
-import { MapService } from './map.service';
+import { KaKaoMapController } from './map.kakao.controller';
+import { KakaoMapService } from './map.kakao.service';
+// import { MapController } from './map.controller';
+// import { MapService } from './map.service';
 
 @Global()
 @Module({
-  controllers: [MapController],
-  providers: [MapService],
+  // controllers: [MapController],
+  // providers: [MapService],
+  controllers: [KaKaoMapController],
+  providers: [KakaoMapService],
 })
 export class MapModule {}


### PR DESCRIPTION
## 개요 📖


- #25 
- 기존 네이버 검색은 5개밖에 나오지 않아 카카오로 바꿨다.


## 설명 📄


### 기능1: 검색어와 유사도 기준

- https://jijihuny.store/map/v2/searchByAccuracy?keyword={keyword} 
### 기능2: 검색 결과 거리순 출력

- https://jijihuny.store/map/v2/searchByDistance?keyword={keyword}&x={x}&y={y} 
- ex) http://jijihuny.store/map/v2/searchByDistance?keyword=고기=126.7815676147119&y=37.65111857134181


## 고민거리 🤔 (Optional) - 의견 받고싶은 부분 있으면 적어두기


### 고민1

- 이론상 1350개까지 될 것 같은데 지금은 15개만 나온다.
- 수정 가능할 것 같다. <b>추후 수정사항</b>


## 스크린샷 📷 (Optional) - 스크린샷이 없으면 제거
![image](https://github.com/boostcampwm2023/iOS03-Macro/assets/90089657/8b7ae7fb-ccea-4374-a322-8aaa61c30c7e)


## Close Issues 🔒 (닫을 Issue)

Close #25 


공통 체크 리스트
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 작업에 맞는 label을 추가했는지 확인
- [x] 컨벤션 지켰는지 확인


