### PR TITLE
[Improve][#25] kakao search 15 items to 45items

### DIFF
--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { Public } from './auth/auth.decorators';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @Public()
   getHello(): string {
     return this.appService.getHello();
   }

--- a/server/src/map/map.kakao.controller.ts
+++ b/server/src/map/map.kakao.controller.ts
@@ -12,19 +12,20 @@ export class KaKaoMapController {
   @ApiResponse({ type: [KakaoMapSearchResponse] })
   @Public()
   @Get('searchByAccuracy')
-  async searchByAccuracy(@Query('keyword') keyword: string) {
-    return await this.kakaoMapService.kakaoSearchByAccuracy(keyword);
+  async searchByAccuracy(@Query('keyword') keyword: string, @Query('pagenum') pagenum: number) {
+    return await this.kakaoMapService.kakaoSearchByAccuracy(keyword,pagenum);
   }
 
   @ApiOperation({ description: '주소나 이름에 따라 위치를 검색합니다.' })
   @ApiResponse({ type: [KakaoMapSearchResponse] })
   @Public()
-  @Get('earchByDistance')
+  @Get('searchByDistance')
   async searchByDistance(
     @Query('keyword') keyword: string,
+    @Query('pagenum') pagenum: number,
     @Query('x') x: number,
     @Query('y') y: number,
   ) {
-    return await this.kakaoMapService.kakaoSearchByDistance(keyword, x, y);
+    return await this.kakaoMapService.kakaoSearchByDistance(keyword, pagenum, x, y);
   }
 }

--- a/server/src/map/map.kakao.controller.ts
+++ b/server/src/map/map.kakao.controller.ts
@@ -3,6 +3,8 @@ import { KakaoMapSearchResponse } from './map.kakao.search.response.dto';
 import { KakaoMapService } from './map.kakao.service';
 import { Controller, Get, Query } from '@nestjs/common';
 import { Public } from 'src/auth/auth.decorators';
+import { KakaoSearchAccuracyQuery } from './map.kakao.search.accuracy.query.dto';
+import { KakaoSearchDistanceQuery } from './map.kakao.search.distance.query.dto';
 
 @Controller('map/v2')
 export class KaKaoMapController {
@@ -12,20 +14,15 @@ export class KaKaoMapController {
   @ApiResponse({ type: [KakaoMapSearchResponse] })
   @Public()
   @Get('searchByAccuracy')
-  async searchByAccuracy(@Query('keyword') keyword: string, @Query('pagenum') pagenum: number) {
-    return await this.kakaoMapService.kakaoSearchByAccuracy(keyword,pagenum);
+  async searchByAccuracy(@Query() query: KakaoSearchAccuracyQuery) {
+    return await this.kakaoMapService.kakaoSearchByAccuracy(query);
   }
 
   @ApiOperation({ description: '주소나 이름에 따라 위치를 검색합니다.' })
   @ApiResponse({ type: [KakaoMapSearchResponse] })
   @Public()
   @Get('searchByDistance')
-  async searchByDistance(
-    @Query('keyword') keyword: string,
-    @Query('pagenum') pagenum: number,
-    @Query('x') x: number,
-    @Query('y') y: number,
-  ) {
-    return await this.kakaoMapService.kakaoSearchByDistance(keyword, pagenum, x, y);
+  async searchByDistance(@Query() query: KakaoSearchDistanceQuery) {
+    return await this.kakaoMapService.kakaoSearchByDistance(query);
   }
 }

--- a/server/src/map/map.kakao.search.accuracy.query.dto.ts
+++ b/server/src/map/map.kakao.search.accuracy.query.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString } from 'class-validator';
+
+export class KakaoSearchAccuracyQuery {
+  @ApiProperty({ description: '키워드' })
+  @IsString()
+  keyword: string;
+
+  @ApiProperty({ description: '페이지' })
+  @IsNumber()
+  pagenum: number;
+}

--- a/server/src/map/map.kakao.search.distance.query.dto.ts
+++ b/server/src/map/map.kakao.search.distance.query.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { KakaoSearchAccuracyQuery } from './map.kakao.search.accuracy.query.dto';
+import { IsNumber } from 'class-validator';
+
+export class KakaoSearchDistanceQuery extends KakaoSearchAccuracyQuery {
+  @ApiProperty({ description: 'x 좌표' })
+  @IsNumber()
+  x: number;
+
+  @ApiProperty({ description: 'y 좌표' })
+  @IsNumber()
+  y: number;
+}

--- a/server/src/map/map.kakao.service.ts
+++ b/server/src/map/map.kakao.service.ts
@@ -6,7 +6,6 @@ import { KakaoMapSearchResponse } from './map.kakao.search.response.dto';
 import { AxiosResponse } from 'axios';
 import { map } from 'rxjs';
 
-const pagenum = 1;
 const sizenum = 15;
 
 @Injectable()
@@ -16,7 +15,7 @@ export class KakaoMapService {
     private readonly configService: ConfigService,
   ) {}
 
-  async kakaoSearchByAccuracy(keyword: string) {
+  async kakaoSearchByAccuracy(keyword: string, pagenum: number) {
     return this.httpService
       .get(
         this.configService.get('kakao.search.url') +
@@ -37,7 +36,7 @@ export class KakaoMapService {
       );
   }
 
-  async kakaoSearchByDistance(keyword: string, x: number, y: number) {
+  async kakaoSearchByDistance(keyword: string, pagenum: number, x: number, y: number) {
     return this.httpService
       .get(
         this.configService.get('kakao.search.url') +

--- a/server/src/map/map.kakao.service.ts
+++ b/server/src/map/map.kakao.service.ts
@@ -5,6 +5,8 @@ import { plainToInstance } from 'class-transformer';
 import { KakaoMapSearchResponse } from './map.kakao.search.response.dto';
 import { AxiosResponse } from 'axios';
 import { map } from 'rxjs';
+import { KakaoSearchAccuracyQuery } from './map.kakao.search.accuracy.query.dto';
+import { KakaoSearchDistanceQuery } from './map.kakao.search.distance.query.dto';
 
 const sizenum = 15;
 
@@ -15,7 +17,7 @@ export class KakaoMapService {
     private readonly configService: ConfigService,
   ) {}
 
-  async kakaoSearchByAccuracy(keyword: string, pagenum: number) {
+  async kakaoSearchByAccuracy({ keyword, pagenum }: KakaoSearchAccuracyQuery) {
     return this.httpService
       .get(
         this.configService.get('kakao.search.url') +
@@ -36,7 +38,12 @@ export class KakaoMapService {
       );
   }
 
-  async kakaoSearchByDistance(keyword: string, pagenum: number, x: number, y: number) {
+  async kakaoSearchByDistance({
+    keyword,
+    pagenum,
+    x,
+    y,
+  }: KakaoSearchDistanceQuery) {
     return this.httpService
       .get(
         this.configService.get('kakao.search.url') +


### PR DESCRIPTION
## 개요 📖


- #25 
- 기존에는 pagenum이 1로만 지정되어 있었는데, pagenum을 parameter로 넣을 수 있게 바꿔줬다.


## 설명 📄

- ex) jijihuny.store/map/v2/searchByAccuracy?keyword="부평 라멘"&pagenum=2
- ex) jijihuny.store/map/v2/searchByDistance?keyword=라멘&pagenum=2&x=126.7815676147119&y=37.65111857134181
- 이론상 1350개라고 했는데 문서랑 실제 허용 범위가 달라서 해보니 실제로는 45개였다.
- pagenum은 1,2,3만 가능하다. 그 이후부터는 3과 같은 값들이 출력됨.


## Close Issues 🔒 (닫을 Issue) 

Close #25 

공통 체크 리스트
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 작업에 맞는 label을 추가했는지 확인
- [x] 컨벤션 지켰는지 확인

