### PR TITLE
[feat] [#12] 인증 로직 분리 User => Auth, Access Token refresh api 구현

### DIFF
--- a/server/src/auth/apple/apple.auth.controller.ts
+++ b/server/src/auth/apple/apple.auth.controller.ts
@@ -14,7 +14,7 @@ export class AppleAuthController {
 
   @ApiOperation({
     description:
-      'Apple 로그인 혹은 회원가입을 실행하여 refresh token과 access token을 반환합니다.',
+      'Apple 로그인 혹은 회원가입을 실행하여 access token을 반환합니다.',
   })
   @ApiResponse({ type: AppleClientAuthResponse })
   @Public()

--- a/server/src/auth/apple/apple.auth.controller.ts
+++ b/server/src/auth/apple/apple.auth.controller.ts
@@ -30,7 +30,7 @@ export class AppleAuthController {
     description: 'Apple 회원탈퇴를 진행합니다. 테스트필요',
   })
   @Delete('revoke')
-  async refresh(@Body() payload: AppleClientRevokeBody) {
+  async revoke(@Body() payload: AppleClientRevokeBody) {
     await this.appleAuthService.revoke(payload);
   }
 }

--- a/server/src/auth/apple/apple.auth.service.ts
+++ b/server/src/auth/apple/apple.auth.service.ts
@@ -205,7 +205,7 @@ export class AppleAuthService {
 
   private createToken(user: Authentication) {
     return {
-      accessToken: this.jwtService.sign(user)
+      accessToken: this.jwtService.sign(user),
     };
   }
 

--- a/server/src/auth/apple/apple.auth.service.ts
+++ b/server/src/auth/apple/apple.auth.service.ts
@@ -205,10 +205,7 @@ export class AppleAuthService {
 
   private createToken(user: Authentication) {
     return {
-      accessToken: this.jwtService.sign(user),
-      expiresIn: this.configService.get(
-        'application.jwt.signOptions.expiresIn',
-      ),
+      accessToken: this.jwtService.sign(user)
     };
   }
 

--- a/server/src/auth/apple/apple.client.auth.response.dto.ts
+++ b/server/src/auth/apple/apple.client.auth.response.dto.ts
@@ -1,3 +1,3 @@
-import { UserSigninResponse } from 'src/user/user.signin.response.dto';
+import { AuthBasicAuthResponse } from '../auth.basic.auth.response.dto';
 
-export class AppleClientAuthResponse extends UserSigninResponse {}
+export class AppleClientAuthResponse extends AuthBasicAuthResponse {}

--- a/server/src/auth/apple/apple.client.auth.response.dto.ts
+++ b/server/src/auth/apple/apple.client.auth.response.dto.ts
@@ -1,13 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsJWT, IsOptional } from 'class-validator';
+import { UserSigninResponse } from 'src/user/user.signin.response.dto';
 
-export class AppleClientAuthResponse {
-  @ApiProperty({ description: 'access-token 애플 것이 아니라 우리 거' })
-  @IsJWT()
-  accessToken: string;
-
-  @ApiProperty({ description: '만료' })
-  @IsDate()
-  @IsOptional()
-  expiresIn?: Date;
-}
+export class AppleClientAuthResponse extends UserSigninResponse {}

--- a/server/src/auth/auth.basic.auth.response.dto.ts
+++ b/server/src/auth/auth.basic.auth.response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsJWT, IsNotEmpty } from 'class-validator';
 
-export class UserSigninResponse {
+export class AuthBasicAuthResponse {
   @ApiProperty({ description: '로그인 응답으로 제공되는 access token입니다.' })
   @IsJWT()
   @IsNotEmpty()

--- a/server/src/auth/auth.basic.signin.body.dto.ts
+++ b/server/src/auth/auth.basic.signin.body.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
 
-export class UserSigninBody {
+export class AuthBasicSigninBody {
   @ApiProperty({ description: 'id email' })
   @IsEmail()
   email: string;

--- a/server/src/auth/auth.basic.signup.body.dto.ts
+++ b/server/src/auth/auth.basic.signup.body.dto.ts
@@ -8,7 +8,7 @@ import {
   MinLength,
 } from 'class-validator';
 
-export class UserSignupBody {
+export class AuthBasicSignupBody {
   @ApiProperty({ description: '이메일' })
   @IsEmail()
   email: string;

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Post, Put } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthService } from './auth.service';
+import { AuthBasicSigninBody } from './auth.basic.signin.body.dto';
+import { plainToInstance } from 'class-transformer';
+import { AuthBasicAuthResponse } from './auth.basic.auth.response.dto';
+import { AuthBasicSignupBody } from './auth.basic.signup.body.dto';
+import { AuthenticatedUser, Public } from './auth.decorators';
+import { Authentication } from './authentication.dto';
+
+@ApiTags('Auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @ApiOperation({
+    description:
+      '가장 기본이 되는 회원가입 로직입니다. 이메일 비밀 번호 등을 사용합니다.',
+  })
+  @ApiResponse({ type: AuthBasicAuthResponse })
+  @Post('signup')
+  @Public()
+  async signup(user: AuthBasicSignupBody) {
+    return plainToInstance(
+      AuthBasicAuthResponse,
+      await this.authService.createUser(user),
+    );
+  }
+
+  @ApiOperation({ description: '이메일 비밀번호를 통해 로그인합니다.' })
+  @ApiResponse({ type: AuthBasicAuthResponse })
+  @Post('signin')
+  @Public()
+  async signin(user: AuthBasicSigninBody) {
+    return plainToInstance(
+      AuthBasicAuthResponse,
+      await this.authService.login(user),
+    );
+  }
+
+  @ApiOperation({
+    description: 'Access Token의 만료기한을 갱신하여 응답합니다.',
+  })
+  @ApiResponse({ type: AuthBasicAuthResponse })
+  @Put('refresh')
+  async refresh(@AuthenticatedUser() user: Authentication) {
+    return plainToInstance(
+      AuthBasicAuthResponse,
+      await this.authService.refreshAccessToken(user),
+    );
+  }
+}

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -7,9 +7,11 @@ import { ConfigService } from '@nestjs/config';
 import { AppleAuthModule } from './apple/apple.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from 'src/entities/user.entity';
 
 @Module({
-  imports: [AppleAuthModule],
+  imports: [AppleAuthModule, TypeOrmModule.forFeature([User])],
   controllers: [AuthController],
   providers: [
     {

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -5,9 +5,12 @@ import { JwtAuthenticationGuard } from './jwt.authentication.gaurd';
 import { RoleAuthorizationGuard } from './role.authorization.gaurd';
 import { ConfigService } from '@nestjs/config';
 import { AppleAuthModule } from './apple/apple.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 
 @Module({
   imports: [AppleAuthModule],
+  controllers: [AuthController],
   providers: [
     {
       provide: APP_GUARD,
@@ -23,6 +26,7 @@ import { AppleAuthModule } from './apple/apple.module';
       useFactory: (configService: ConfigService) =>
         configService.get('application.jwt.secret'),
     },
+    AuthService,
   ],
 })
 export class AuthModule {}

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,0 +1,50 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from 'src/entities/user.entity';
+import { Repository } from 'typeorm';
+import { AuthBasicSignupBody } from './auth.basic.signup.body.dto';
+import { JwtService } from '@nestjs/jwt';
+import { Authentication } from './authentication.dto';
+import { plainToInstance } from 'class-transformer';
+import { hash, genSalt, compare } from 'bcrypt';
+import { AuthBasicSigninBody } from './auth.basic.signin.body.dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async createUser(user: AuthBasicSignupBody) {
+    const userDetail = await this.userRepository.save({
+      ...user,
+      password: await hash(user.password, await genSalt()),
+    });
+    return await this.createAccessToken(
+      plainToInstance(Authentication, userDetail),
+    );
+  }
+
+  async login({ email, password }: AuthBasicSigninBody) {
+    const userDetail = await this.userRepository.findOneOrFail({
+      where: { email },
+      select: ['email', 'password', 'role'],
+    });
+    if (!(await compare(password, userDetail.password))) {
+      throw new BadRequestException('invalid password');
+    }
+    return await this.createAccessToken(
+      plainToInstance(Authentication, userDetail),
+    );
+  }
+
+  async refreshAccessToken(user: Authentication) {
+    return await this.jwtService.signAsync(user);
+  }
+
+  private async createAccessToken(user: Authentication) {
+    return await this.jwtService.signAsync(user);
+  }
+}

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
@@ -33,7 +33,7 @@ export class AuthService {
       select: ['email', 'password', 'role'],
     });
     if (!(await compare(password, userDetail.password))) {
-      throw new BadRequestException('invalid password');
+      throw new UnauthorizedException('invalid password');
     }
     return await this.createAccessToken(
       plainToInstance(Authentication, userDetail),

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -15,55 +15,17 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { UserSigninResponse } from './user.signin.response.dto';
-import { UserSignupBody } from './user.signup.body.dto';
-import { UserSigninBody } from './user.signin.body.dto';
 import { UserProfileUpdateQuery } from './user.profile.update.query.dto';
 import { UserProfileResponse } from './user.profile.response.dto';
 import { UserProfileQuery } from './user.profile.query.dto';
 import { UserFollowQuery } from './user.follow.query.dto';
 import { UserProfileSimpleResponse } from './user.profile.simple.response.dto';
 import { UserService } from './user.service';
-import { UserDeleteBody } from './user.delete.body.dto';
-import { Public } from 'src/auth/auth.decorators';
-import { plainToInstance } from 'class-transformer';
 
 @ApiTags('User')
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
-
-  @ApiOperation({ description: '회원가입' })
-  @ApiResponse({ type: UserSigninResponse })
-  @Public()
-  @Post('signup')
-  async signup(@Body() user: UserSignupBody) {
-    return plainToInstance(UserSigninResponse, {
-      token: await this.userService.signup(user),
-    });
-  }
-
-  @ApiOperation({ description: '기본 로그인' })
-  @ApiResponse({ type: UserSigninResponse })
-  @Public()
-  @Post('signin')
-  async signin(@Body() user: UserSigninBody) {
-    return plainToInstance(UserSigninResponse, {
-      token: await this.userService.login(user),
-    });
-  }
-
-  @ApiOperation({ description: '로그아웃' })
-  @ApiBearerAuth('access-token')
-  @Post('signout')
-  async signout() {}
-
-  @ApiOperation({ description: '회원탈퇴' })
-  @ApiBearerAuth('access-token')
-  @Delete('delete')
-  async delete(@Body() user: UserDeleteBody) {
-    return await this.userService.delete(user);
-  }
 
   @ApiOperation({ description: '회원정보 수정' })
   @ApiBearerAuth('access-token')

--- a/server/src/user/user.delete.body.dto.ts
+++ b/server/src/user/user.delete.body.dto.ts
@@ -1,8 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail } from 'class-validator';
-
-export class UserDeleteBody {
-  @ApiProperty({ description: 'id email' })
-  @IsEmail()
-  email: string;
-}

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -2,46 +2,11 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
-import { UserSigninBody } from './user.signin.body.dto';
-import { UserSignupBody } from './user.signup.body.dto';
-import { UserDeleteBody } from './user.delete.body.dto';
-import { JwtService } from '@nestjs/jwt';
-import { compare, genSalt, hash } from 'bcrypt';
 
 @Injectable()
 export class UserService {
   constructor(
     @InjectRepository(User)
-    private readonly userRepository: Repository<User>,
-    private readonly jwtService: JwtService,
+    private readonly userRepository: Repository<User>
   ) {}
-
-  async signup(user: UserSignupBody) {
-    const userDetail = await this.userRepository.save({
-      ...user,
-      password: await hash(user.password, await genSalt()),
-    });
-    return await this.jwtService.signAsync({
-      email: userDetail.email,
-      role: userDetail.role,
-    });
-  }
-
-  async login(user: UserSigninBody) {
-    const userDetail = await this.userRepository.findOneOrFail({
-      where: { email: user.email },
-    });
-    if (await compare(user.password, userDetail.password)) {
-      return await this.jwtService.signAsync({
-        email: userDetail.email,
-        role: userDetail.role,
-      });
-    } else {
-      throw new UnauthorizedException('user not found');
-    }
-  }
-
-  async delete(user: UserDeleteBody) {
-    return await this.userRepository.delete({ email: user.email });
-  }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -7,6 +7,6 @@ import { Repository } from 'typeorm';
 export class UserService {
   constructor(
     @InjectRepository(User)
-    private readonly userRepository: Repository<User>
+    private readonly userRepository: Repository<User>,
   ) {}
 }

--- a/server/src/user/user.signin.response.dto.ts
+++ b/server/src/user/user.signin.response.dto.ts
@@ -2,8 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsJWT, IsNotEmpty } from 'class-validator';
 
 export class UserSigninResponse {
-  @ApiProperty({ description: 'jwt token' })
+  @ApiProperty({ description: '로그인 응답으로 제공되는 access token입니다.' })
   @IsJWT()
   @IsNotEmpty()
-  token: string;
+  accessToken: string;
 }


### PR DESCRIPTION
## 개요 📖

- #12 
- 로그인 로직 플로우를 유저 영역에서 분리하여 별도의 auth 영역으로 분리하였습니다.
- access token을 갱신하기 위한 api를 추가하였습니다.
 

## 설명 📄

- 원래 유저 인증과 관련한 기본 로직은 User api와 강하게 결합되어 있었습니다.
```
./src/user
├── user.controller.ts
├── user.delete.body.dto.ts
├── user.follow.query.dto.ts
├── user.module.ts
├── user.profile.query.dto.ts
├── user.profile.response.dto.ts
├── user.profile.simple.response.dto.ts
├── user.profile.update.query.dto.ts
├── user.service.ts
├── user.signin.body.dto.ts
├── user.signin.response.dto.ts
└── user.signup.body.dto.ts
```

```ts
@ApiTags('User')
@Controller('user')
export class UserController {
  constructor(private readonly userService: UserService) {}

  @ApiOperation({ description: '회원가입' })
  @ApiResponse({ type: UserSigninResponse })
  @Public()
  @Post('signup')
  async signup(@Body() user: UserSignupBody) {
    return plainToInstance(UserSigninResponse, {
      token: await this.userService.signup(user),
    });
  }

  @ApiOperation({ description: '기본 로그인' })
  @ApiResponse({ type: UserSigninResponse })
  @Public()
  @Post('signin')
  async signin(@Body() user: UserSigninBody) {
    return plainToInstance(UserSigninResponse, {
      token: await this.userService.login(user),
    });
  }

  @ApiOperation({ description: '로그아웃' })
  @ApiBearerAuth('access-token')
  @Post('signout')
  async signout() {}

  @ApiOperation({ description: '회원탈퇴' })
  @ApiBearerAuth('access-token')
  @Delete('delete')
  async delete(@Body() user: UserDeleteBody) {
    return await this.userService.delete(user);
  }
...
}
```
그러나, login, refresh 등 인증과 직접적으로 관련된 api들이 user와 결합되어
apple login 등을 통해 얻은 access token 조차도  user login을 통해 처리해야만 했습니다.

또한 user api에서는 user에 대한 인증 로직 또한 혼재되어 온전히 비즈니스 로직에 집중하기 어려워졌습니다.
이에 인증 로직을 따로 분리하여 auth 모듈을 통해 인증 관련 로직을 완전히 담당하고,
user 모듈에서는 유저에 관한 비즈니스 로직에만 온전히 집중하도록 하고자 작업했습니다.

```
./src/user
├── mysql.config.ts
├── user.controller.ts
├── user.follow.query.dto.ts
├── user.module.ts
├── user.profile.query.dto.ts
├── user.profile.response.dto.ts
├── user.profile.simple.response.dto.ts
├── user.profile.update.query.dto.ts
└── user.service.ts
```
```
./src/auth
├── apple
│   ├── apple.auth.controller.ts
│   ├── apple.auth.revoke.body.dto.ts
│   ├── apple.auth.service.ts
│   ├── apple.auth.token.body.dto.ts
│   ├── apple.auth.token.response.dto.ts
│   ├── apple.client.auth.body.dto.ts
│   ├── apple.client.auth.response.dto.ts
│   ├── apple.client.revoke.body.dto.ts
│   ├── apple.identity.token.header.dto.ts
│   ├── apple.identity.token.payload.dto.ts
│   ├── apple.identity.token.public.keys.response.dto.ts
│   └── apple.module.ts
├── auth.basic.auth.response.dto.ts
├── auth.basic.signin.body.dto.ts
├── auth.basic.signup.body.dto.ts
├── auth.constants.ts
├── auth.controller.ts
├── auth.decorators.ts
├── auth.module.ts
├── auth.service.ts
├── authentication.dto.ts
├── jwt.authentication.gaurd.ts
└── role.authorization.gaurd.ts
```

## 고민거리 🤔 
### Q1 OAuth2 인증 로직을 추상화할 수 있을 것 같으나 시간적으로 굳이 이것에 집중하기 보단 비즈니스 로직과 인프라에 집중하는 것이 좋을 것 같다..

### Q2 이로 인해 Auth 관련 파일들이 좀 많이 복잡해진 것 같다..

공통 체크 리스트
- [ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] 작업에 맞는 label을 추가했는지 확인
- [ ] 컨벤션 지켰는지 확인
