### PR TITLE
[fix][#50] 유저 이미지 정보가 보이지 않던 버그 수정

### DIFF
--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/PostProfileView.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/PostProfileView.swift
@@ -132,7 +132,7 @@ extension PostProfileView {
     }
     
     func configure(item: PostFindResponse) {
-        loadImage(profileImageStringURL: item.userInfo.name) { profileImage in
+        loadImage(profileImageStringURL: item.userInfo.imageUrl) { profileImage in
             DispatchQueue.main.async { [self] in
                 if let image = profileImage {
                     profileImageView.image = image


### PR DESCRIPTION
## 개요 📖

유저가 작성한 글에서, 유저의 이미지가 보이지 않던 버그 수정필요

## 설명 📄

유저가 작성한 글에서 유저의 이미지가 보이도록 버그 수정


