### PR TITLE
[enhancement] PostCollectionView, Common UI 로 활용 가능하도록 수정

### DIFF
--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -36,11 +36,7 @@
 		BA32E1952B0DEBC500EA0EE2 /* LocationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32E1942B0DEBC500EA0EE2 /* LocationInfoViewController.swift */; };
 		BA33AA702B0AF9DD0065D1E0 /* TaBarBackgroundLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA6F2B0AF9DD0065D1E0 /* TaBarBackgroundLineView.swift */; };
 		BA33AA852B0AF9F30065D1E0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA742B0AF9F20065D1E0 /* HomeViewModel.swift */; };
-		BA33AA872B0AF9F30065D1E0 /* HomeCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA772B0AF9F20065D1E0 /* HomeCollectionView.swift */; };
-		BA33AA882B0AF9F30065D1E0 /* PostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA782B0AF9F20065D1E0 /* PostCollectionViewCell.swift */; };
 		BA33AA892B0AF9F30065D1E0 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA792B0AF9F20065D1E0 /* HomeViewController.swift */; };
-		BA33AA8A2B0AF9F30065D1E0 /* PostProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA7A2B0AF9F20065D1E0 /* PostProfileView.swift */; };
-		BA33AA8B2B0AF9F30065D1E0 /* PostContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA7B2B0AF9F20065D1E0 /* PostContentView.swift */; };
 		BA33AA8C2B0AF9F30065D1E0 /* HomeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA33AA7C2B0AF9F20065D1E0 /* HomeHeaderView.swift */; };
 		BA6C6DF32B05FFC500563B22 /* CAGradientLayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C6DE22B05FFC400563B22 /* CAGradientLayer+.swift */; };
 		BA6C6DF42B05FFC500563B22 /* CircularViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C6DE32B05FFC400563B22 /* CircularViewProtocol.swift */; };
@@ -65,6 +61,11 @@
 		BA8DC4182B0B6AD400929E01 /* MacroDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = BA8DC4172B0B6AD400929E01 /* MacroDesignSystem */; };
 		BA8DC41B2B0B6ADD00929E01 /* MacroNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = BA8DC41A2B0B6ADD00929E01 /* MacroNetwork */; };
 		BA90CB3B2B0EF88700365AE2 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA90CB3A2B0EF88700365AE2 /* LocationManager.swift */; };
+		BA90CB7E2B0F3BA500365AE2 /* PostCollectionViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA90CB7D2B0F3BA500365AE2 /* PostCollectionViewProtocol.swift */; };
+		BA90CB842B0F3BF600365AE2 /* PostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA90CB802B0F3BF600365AE2 /* PostCollectionViewCell.swift */; };
+		BA90CB852B0F3BF600365AE2 /* PostProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA90CB812B0F3BF600365AE2 /* PostProfileView.swift */; };
+		BA90CB862B0F3BF600365AE2 /* PostContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA90CB822B0F3BF600365AE2 /* PostContentView.swift */; };
+		BA90CB872B0F3BF600365AE2 /* PostCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA90CB832B0F3BF600365AE2 /* PostCollectionView.swift */; };
 		BADB1F0C2B0B72AE0001CCD9 /* NetworkUnresearchableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADB1F0B2B0B72AE0001CCD9 /* NetworkUnresearchableViewController.swift */; };
 		D241DC6E2B0D9FFE0037DDB6 /* SearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC6D2B0D9FFE0037DDB6 /* SearchUseCase.swift */; };
 		D241DC712B0DA0070037DDB6 /* CommonUIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC702B0DA0070037DDB6 /* CommonUIComponents.swift */; };
@@ -119,11 +120,7 @@
 		BA33AA6F2B0AF9DD0065D1E0 /* TaBarBackgroundLineView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaBarBackgroundLineView.swift; sourceTree = "<group>"; };
 		BA33AA742B0AF9F20065D1E0 /* HomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		BA33AA752B0AF9F20065D1E0 /* .gitkeep */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
-		BA33AA772B0AF9F20065D1E0 /* HomeCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeCollectionView.swift; sourceTree = "<group>"; };
-		BA33AA782B0AF9F20065D1E0 /* PostCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCollectionViewCell.swift; sourceTree = "<group>"; };
 		BA33AA792B0AF9F20065D1E0 /* HomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
-		BA33AA7A2B0AF9F20065D1E0 /* PostProfileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostProfileView.swift; sourceTree = "<group>"; };
-		BA33AA7B2B0AF9F20065D1E0 /* PostContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostContentView.swift; sourceTree = "<group>"; };
 		BA33AA7C2B0AF9F20065D1E0 /* HomeHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeHeaderView.swift; sourceTree = "<group>"; };
 		BA6C6DE22B05FFC400563B22 /* CAGradientLayer+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CAGradientLayer+.swift"; sourceTree = "<group>"; };
 		BA6C6DE32B05FFC400563B22 /* CircularViewProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularViewProtocol.swift; sourceTree = "<group>"; };
@@ -146,6 +143,11 @@
 		BA8DC4122B0B602000929E01 /* WriteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewModel.swift; sourceTree = "<group>"; };
 		BA8DC4142B0B602D00929E01 /* WriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewController.swift; sourceTree = "<group>"; };
 		BA90CB3A2B0EF88700365AE2 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		BA90CB7D2B0F3BA500365AE2 /* PostCollectionViewProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCollectionViewProtocol.swift; sourceTree = "<group>"; };
+		BA90CB802B0F3BF600365AE2 /* PostCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCollectionViewCell.swift; sourceTree = "<group>"; };
+		BA90CB812B0F3BF600365AE2 /* PostProfileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostProfileView.swift; sourceTree = "<group>"; };
+		BA90CB822B0F3BF600365AE2 /* PostContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostContentView.swift; sourceTree = "<group>"; };
+		BA90CB832B0F3BF600365AE2 /* PostCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCollectionView.swift; sourceTree = "<group>"; };
 		BADB1F0B2B0B72AE0001CCD9 /* NetworkUnresearchableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUnresearchableViewController.swift; sourceTree = "<group>"; };
 		D241DC6D2B0D9FFE0037DDB6 /* SearchUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchUseCase.swift; sourceTree = "<group>"; };
 		D241DC702B0DA0070037DDB6 /* CommonUIComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommonUIComponents.swift; sourceTree = "<group>"; };
@@ -505,11 +507,7 @@
 		BA33AA762B0AF9F20065D1E0 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				BA33AA772B0AF9F20065D1E0 /* HomeCollectionView.swift */,
-				BA33AA782B0AF9F20065D1E0 /* PostCollectionViewCell.swift */,
 				BA33AA792B0AF9F20065D1E0 /* HomeViewController.swift */,
-				BA33AA7A2B0AF9F20065D1E0 /* PostProfileView.swift */,
-				BA33AA7B2B0AF9F20065D1E0 /* PostContentView.swift */,
 				BA33AA7C2B0AF9F20065D1E0 /* HomeHeaderView.swift */,
 			);
 			path = View;
@@ -533,6 +531,7 @@
 		BA4ED7272B0B4C52000F0B5B /* CommonProtocol */ = {
 			isa = PBXGroup;
 			children = (
+				BA90CB7D2B0F3BA500365AE2 /* PostCollectionViewProtocol.swift */,
 				BA8DC3F92B0B5DD100929E01 /* BaseViewControllerProtocol.swift */,
 				D263CA232B04134600B4A144 /* ViewModelProtocol.swift */,
 				BA6C6DE32B05FFC400563B22 /* CircularViewProtocol.swift */,
@@ -729,6 +728,17 @@
 			path = UseCases;
 			sourceTree = "<group>";
 		};
+		BA90CB7F2B0F3BF500365AE2 /* PostCollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				BA90CB802B0F3BF600365AE2 /* PostCollectionViewCell.swift */,
+				BA90CB812B0F3BF600365AE2 /* PostProfileView.swift */,
+				BA90CB822B0F3BF600365AE2 /* PostContentView.swift */,
+				BA90CB832B0F3BF600365AE2 /* PostCollectionView.swift */,
+			);
+			path = PostCollectionView;
+			sourceTree = "<group>";
+		};
 		BAA07ADE2B0251CF00884F3C /* Scene */ = {
 			isa = PBXGroup;
 			children = (
@@ -774,6 +784,7 @@
 		D241DC6F2B0DA0070037DDB6 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				BA90CB7F2B0F3BF500365AE2 /* PostCollectionView */,
 				D241DC702B0DA0070037DDB6 /* CommonUIComponents.swift */,
 				AAD0B2D22B0E03DE003B4D5F /* MacroCarouselView.swift */,
 				AAD0B2D42B0E04CA003B4D5F /* MacroCarouselViewCell.swift */,
@@ -1009,9 +1020,10 @@
 				D241DC762B0DA00F0037DDB6 /* PostFindResponse.swift in Sources */,
 				AAD0B2C22B0DA35B003B4D5F /* LoginResponse.swift in Sources */,
 				D241DC7A2B0DA0C00037DDB6 /* PostEndPoint.swift in Sources */,
-				BA33AA8A2B0AF9F30065D1E0 /* PostProfileView.swift in Sources */,
+				BA90CB862B0F3BF600365AE2 /* PostContentView.swift in Sources */,
 				D241DC752B0DA00F0037DDB6 /* UserInfo.swift in Sources */,
 				BA33AA892B0AF9F30065D1E0 /* HomeViewController.swift in Sources */,
+				BA90CB872B0F3BF600365AE2 /* PostCollectionView.swift in Sources */,
 				D263CA132B02DD8900B4A144 /* RouteTableViewController.swift in Sources */,
 				BA90CB3B2B0EF88700365AE2 /* LocationManager.swift in Sources */,
 				BA6C6DF32B05FFC500563B22 /* CAGradientLayer+.swift in Sources */,
@@ -1020,6 +1032,7 @@
 				BA8DC3FA2B0B5DD100929E01 /* BaseViewControllerProtocol.swift in Sources */,
 				BA33AA8C2B0AF9F30065D1E0 /* HomeHeaderView.swift in Sources */,
 				BA32E1762B0DC2F900EA0EE2 /* UserInfoViewModel.swift in Sources */,
+				BA90CB7E2B0F3BA500365AE2 /* PostCollectionViewProtocol.swift in Sources */,
 				BA8DC4132B0B602000929E01 /* WriteViewModel.swift in Sources */,
 				AA46C4B82B02304400856628 /* AppDelegate.swift in Sources */,
 				BA6C6DF92B05FFC500563B22 /* TabBarCenterView.swift in Sources */,
@@ -1035,9 +1048,9 @@
 				BA6C6DF62B05FFC500563B22 /* TabBarViewModel.swift in Sources */,
 				BADB1F0C2B0B72AE0001CCD9 /* NetworkUnresearchableViewController.swift in Sources */,
 				AAD0B2D52B0E04CA003B4D5F /* MacroCarouselViewCell.swift in Sources */,
+				BA90CB842B0F3BF600365AE2 /* PostCollectionViewCell.swift in Sources */,
 				BA6C6DFD2B05FFC500563B22 /* TabBarViewController.swift in Sources */,
 				BA32E17E2B0DC3CB00EA0EE2 /* MyPageViewModel.swift in Sources */,
-				BA33AA872B0AF9F30065D1E0 /* HomeCollectionView.swift in Sources */,
 				AAD0B2C12B0DA35B003B4D5F /* AppleLoginUseCase.swift in Sources */,
 				D263CA2F2B054A0E00B4A144 /* SearchResultViewController.swift in Sources */,
 				BA32E17F2B0DC3CB00EA0EE2 /* MyPageViewController.swift in Sources */,
@@ -1045,9 +1058,7 @@
 				D263CA262B04147E00B4A144 /* TravelViewController.swift in Sources */,
 				BA32E1772B0DC2F900EA0EE2 /* UserInfoViewController.swift in Sources */,
 				AAD0B2982B0B0841003B4D5F /* CacheManager.swift in Sources */,
-				BA33AA882B0AF9F30065D1E0 /* PostCollectionViewCell.swift in Sources */,
 				D263CA242B04134600B4A144 /* ViewModelProtocol.swift in Sources */,
-				BA33AA8B2B0AF9F30065D1E0 /* PostContentView.swift in Sources */,
 				D241DC782B0DA07E0037DDB6 /* PostFindEndPoint.swift in Sources */,
 				D263CA2D2B052ECC00B4A144 /* TravelEndPoint.swift in Sources */,
 				AAD0B2A42B0B0857003B4D5F /* DefaultLoginRepository.swift in Sources */,
@@ -1056,6 +1067,7 @@
 				AAD0B2C02B0DA35B003B4D5F /* LoginEndPoint.swift in Sources */,
 				D241DC712B0DA0070037DDB6 /* CommonUIComponents.swift in Sources */,
 				BA8DC4072B0B5F0600929E01 /* SearchViewController.swift in Sources */,
+				BA90CB852B0F3BF600365AE2 /* PostProfileView.swift in Sources */,
 				BA6C6DFB2B05FFC500563B22 /* TabBarBackgroundLargeCirclceView.swift in Sources */,
 				BA33AA852B0AF9F30065D1E0 /* HomeViewModel.swift in Sources */,
 				AAD0B2BD2B0DA35B003B4D5F /* LoginViewModel.swift in Sources */,

--- a/iOS/Macro/Macro/Common/CommonProtocol/PostCollectionViewProtocol.swift
+++ b/iOS/Macro/Macro/Common/CommonProtocol/PostCollectionViewProtocol.swift
@@ -1,0 +1,37 @@
+//
+//  PostCollectionViewProtocol.swift
+//  Macro
+//
+//  Created by Byeon jinha on 11/23/23.
+//
+
+import Combine
+import UIKit
+
+protocol PostCollectionViewProtocol: AnyObject {
+    var posts: [PostFindResponse] { get set }
+    
+    func navigateToProfileView(userId: String)
+    func navigateToReadView(postId: String)
+    func loadImage(profileImageStringURL: String, completion: @escaping (UIImage?) -> Void)
+    func touchLike(postId: String, compeletion: @escaping (Bool) -> Void)
+}
+
+extension PostCollectionViewProtocol {
+    func loadImage(profileImageStringURL: String, completion: @escaping (UIImage?) -> Void) {
+        guard let url = URL(string: profileImageStringURL) else { return }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            if let data = data, let image = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    completion(image)
+                }
+            } else {
+                completion(nil)
+            }
+        }.resume()
+    }
+    
+    func touchLike(postId: String, compeletion: @escaping (Bool) -> Void) {
+        compeletion(true)
+    }
+}

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
@@ -7,21 +7,25 @@
 
 import UIKit
 
-final class HomeCollectionView: UICollectionView {
+final class PostCollectionView<T: PostCollectionViewProtocol>: UICollectionView,
+                                                               UICollectionViewDelegate,
+                                                               UICollectionViewDataSource,
+                                                               UICollectionViewDelegateFlowLayout {
     
     // MARK: - Properties
     
-    let viewModel: HomeViewModel
+    let viewModel: T
     
     // MARK: - Initialization
     
-    init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout, viewModel: HomeViewModel) {
+    init(frame: CGRect, viewModel: T) {
         self.viewModel = viewModel
+        let layout = UICollectionViewFlowLayout()
         super.init(frame: frame, collectionViewLayout: layout)
         
         self.backgroundColor = UIColor.appColor(.blue1)
         
-        self.register(PostCollectionViewCell.self, forCellWithReuseIdentifier: PostCollectionViewCell.identifier)
+        self.register(PostCollectionViewCell<T>.self, forCellWithReuseIdentifier: "PostCollectionViewCell")
         
         self.showsVerticalScrollIndicator = false
         
@@ -33,59 +37,39 @@ final class HomeCollectionView: UICollectionView {
         fatalError("init(coder:) has not been implemented")
     }
     
-}
-
-extension HomeCollectionView: UICollectionViewDelegate {
+    // MARK: - Methods
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return viewModel.posts.count
     }
-}
-
-extension HomeCollectionView: UICollectionViewDataSource {
+    
     func collectionView(_ collectionView: UICollectionView,
                         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: PostCollectionViewCell.identifier,
-            for: indexPath) as? PostCollectionViewCell else { return UICollectionViewCell()
+            withReuseIdentifier: "PostCollectionViewCell",
+            for: indexPath) as? PostCollectionViewCell<T> else { return UICollectionViewCell()
         }
         let item: PostFindResponse = viewModel.posts[indexPath.row]
         cell.configure(item: item, viewModel: viewModel)
         
         return cell
     }
-}
-
-extension HomeCollectionView: UICollectionViewDelegateFlowLayout {
+    
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: Metrics.cellWidth, height: Metrics.cellHeight)
+        return CGSize(width: UIScreen.width - 20, height: 250)
     }
     
-    func collectionView(_ collectionView: UICollectionView, 
+    func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return Padding.collectionViewMiniMumSpacing
+        return 20
     }
     
-    func collectionView(_ collectionView: UICollectionView, 
+    func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: 0, bottom: Padding.collectionViewBottom, right: 0)
+        return UIEdgeInsets(top: 0, left: 0, bottom: 80, right: 0)
       }
-}
-
-// MARK: - LayoutMetrics
-
-private extension HomeCollectionView {
-    
-    enum Metrics {
-        static let cellWidth: CGFloat = UIScreen.width - 20
-        static let cellHeight: CGFloat = 250
-    }
-    
-    enum Padding {
-        static let collectionViewMiniMumSpacing: CGFloat = 20
-        static let collectionViewBottom: CGFloat = 80
-    }
 }

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
@@ -7,15 +7,15 @@
 
 import UIKit
 
-final class PostCollectionViewCell: UICollectionViewCell {
+final class PostCollectionViewCell<T: PostCollectionViewProtocol>: UICollectionViewCell {
     
     // MARK: - UI Components
-    let postContentView: PostContentView = PostContentView()
-    let postProfileView: PostProfileView = PostProfileView()
+    let postContentView: PostContentView = PostContentView<T>()
+    let postProfileView: PostProfileView = PostProfileView<T>()
     
     // MARK: - Properties
-    static let identifier = "PostCollectionViewCell"
-    var homeViewModel: HomeViewModel?
+    let identifier = "PostCollectionViewCell"
+    var homeViewModel: T?
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -43,28 +43,28 @@ private extension PostCollectionViewCell {
     func setLayoutConstraints() {
         NSLayoutConstraint.activate([
             postContentView.topAnchor.constraint(equalTo: self.topAnchor),
-            postContentView.heightAnchor.constraint(equalToConstant: Metrics.postContentViewHeight),
+            postContentView.heightAnchor.constraint(equalToConstant: 200),
             postContentView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             postContentView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             
-            postProfileView.topAnchor.constraint(equalTo: postContentView.bottomAnchor, constant: Padding.postProfileViewTop),
-            postProfileView.heightAnchor.constraint(equalToConstant: Metrics.postProfileViewHeight),
+            postProfileView.topAnchor.constraint(equalTo: postContentView.bottomAnchor, constant: 10),
+            postProfileView.heightAnchor.constraint(equalToConstant: 40),
             postProfileView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             postProfileView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
             
         ])
     }
     
-    func componetConfigure(item: PostFindResponse, viewModel: HomeViewModel) {
+    func componetConfigure(item: PostFindResponse, viewModel: T) {
         if postContentView.viewModel == nil {
             postContentView.setLayout()
-            postContentView.configure(item: item)
             postContentView.bind(viewModel: viewModel)
+            postContentView.configure(item: item)
             }
         if postProfileView.viewModel == nil {
             postProfileView.setLayout()
-            postProfileView.configure(item: item)
             postProfileView.bind(viewModel: viewModel)
+            postProfileView.configure(item: item)
            }
         
     }
@@ -74,24 +74,10 @@ private extension PostCollectionViewCell {
 
 extension PostCollectionViewCell {
     
-    func configure(item: PostFindResponse, viewModel: HomeViewModel) {
+    func configure(item: PostFindResponse, viewModel: T) {
         setTranslatesAutoresizingMaskIntoConstraints()
         addsubviews()
         setLayoutConstraints()
         componetConfigure(item: item, viewModel: viewModel)
-    }
-}
-
-// MARK: - LayoutMetrics
-
-private extension PostCollectionViewCell {
-    
-    enum Metrics {
-        static let postContentViewHeight: CGFloat = 200
-        static let postProfileViewHeight: CGFloat = 40
-    }
-    
-    enum Padding {
-        static let postProfileViewTop: CGFloat = 10
     }
 }

--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
@@ -11,22 +11,17 @@ import UIKit
 
 final class HomeViewController: UIViewController {
     
-    // MARK: - UI Components
-    
-    private let homeHeaderView: HomeHeaderView = HomeHeaderView()
-    lazy var homeCollectionView: HomeCollectionView = HomeCollectionView(frame: .zero, collectionViewLayout: homeCollectionViewLayout, viewModel: viewModel)
-    
     // MARK: - Properties
     
     private let viewModel: HomeViewModel
     private let inputSubject: PassthroughSubject<HomeViewModel.Input, Never> = .init()
     private let provider = APIProvider(session: URLSession.shared)
     private var cancellables = Set<AnyCancellable>()
-    private var homeCollectionViewLayout: UICollectionViewFlowLayout {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .vertical
-        return layout
-    }
+    
+    // MARK: - UI Components
+    
+    private let homeHeaderView: HomeHeaderView = HomeHeaderView()
+    lazy var homeCollectionView: PostCollectionView = PostCollectionView(frame: .zero, viewModel: viewModel)
     
     // MARK: - Initialization
     
@@ -48,7 +43,7 @@ final class HomeViewController: UIViewController {
         inputSubject.send(.searchMockPost)
         setUpLayout()
     }
-    
+
 }
 
 // MARK: UI Settings
@@ -101,7 +96,7 @@ private extension HomeViewController {
     }
     
     func navigateToProfileView(_ userId: String) {
-        let userInfoViewModel = UserInfoViewModel()
+        let userInfoViewModel = UserInfoViewModel(postSearcher: viewModel.postSearcher)
         let userInfoViewController = UserInfoViewController(viewModel: userInfoViewModel, userInfo: userId)
 
         navigationController?.pushViewController(userInfoViewController, animated: true)

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Byeon jinha on 11/21/23.
 //
 
+import Combine
 import UIKit
 
 final class UserInfoViewController: UIViewController {
@@ -12,8 +13,11 @@ final class UserInfoViewController: UIViewController {
     // MARK: - Properties
     
     let viewModel: UserInfoViewModel
+    private let inputSubject: PassthroughSubject<UserInfoViewModel.Input, Never> = .init()
+    private var cancellables = Set<AnyCancellable>()
     
     // MARK: - UI Components
+    lazy var homeCollectionView: PostCollectionView = PostCollectionView(frame: .zero, viewModel: viewModel)
     
     let label: UILabel = {
         let label = UILabel()
@@ -21,41 +25,85 @@ final class UserInfoViewController: UIViewController {
         return label
     }()
     
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        self.view.backgroundColor = UIColor.appColor(.blue1)
+        bind()
+        inputSubject.send(.searchMockPost)
+        setUpLayout()
+        super.viewDidLoad()
+    }
+    
+    // MARK: - Init
+    
     init(viewModel: UserInfoViewModel, userInfo: String) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        self.view.backgroundColor = UIColor.appColor(.blue1)
         label.text = userInfo
-        setLayout()
+        
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
 }
+
+// MARK: - UI Settings
 
 private extension UserInfoViewController {
     
     func setTranslatesAutoresizingMaskIntoConstraints() {
         label.translatesAutoresizingMaskIntoConstraints = false
+        homeCollectionView.translatesAutoresizingMaskIntoConstraints = false
     }
     
     func addSubviews() {
         self.view.addSubview(label)
+        self.view.addSubview(homeCollectionView)
     }
     
     func setLayoutConstraints() {
         NSLayoutConstraint.activate([
             label.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+            label.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+            
+            homeCollectionView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            homeCollectionView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            homeCollectionView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            homeCollectionView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
         ])
     }
 
-    func setLayout() {
+    func setUpLayout() {
         setTranslatesAutoresizingMaskIntoConstraints()
         addSubviews()
         setLayoutConstraints()
     }
     
+}
+
+// MARK: - Binding
+
+private extension UserInfoViewController {
+    func bind() {
+        let outputSubject = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
+        
+        outputSubject.receive(on: RunLoop.main).sink { [weak self] output in
+            switch output {
+            case let .updateSearchResult(result):
+                self?.updateSearchResult(result)
+            default: break
+            }
+        }.store(in: &cancellables)
+        
+    }
+}
+
+// MARK: - Methods
+
+private extension UserInfoViewController {
+    func updateSearchResult(_ result: [PostFindResponse]) {
+        homeCollectionView.viewModel.posts += result
+        homeCollectionView.reloadData()
+    }
 }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
@@ -9,35 +9,68 @@ import Combine
 import Foundation
 
 class UserInfoViewModel: ViewModelProtocol {
-    
+ 
     // MARK: - Properties
+    
+    var posts: [PostFindResponse] = []
     private var cancellables = Set<AnyCancellable>()
     private let outputSubject = PassthroughSubject<Output, Never>()
+    let postSearcher: SearchUseCase
     
     // MARK: - init
-    init() {
+    
+    init(postSearcher: SearchUseCase) {
+        self.postSearcher = postSearcher
     }
     
     // MARK: - Input
     
     enum Input {
-        
+        case searchMockPost
     }
     
     // MARK: - Output
-
+    
     enum Output {
         case appleLoginCompleted
+        case updateSearchResult([PostFindResponse])
+        case navigateToProfileView(String)
+        case navigateToReadView(String)
     }
     
     // MARK: - Methods
+    
     func transform(with input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
         input
             .sink { [weak self] input in
                 switch input {
+                case .searchMockPost:
+                    self?.searchMockPost()
                 }
             }
             .store(in: &cancellables)
         return outputSubject.eraseToAnyPublisher()
+    }
+    
+    private func searchMockPost() {
+        postSearcher.searchMockPost(json: "tempJson").sink { completion in
+            if case let .failure(error) = completion {
+            }
+        } receiveValue: { [weak self] response in
+            self?.outputSubject.send(.updateSearchResult(response))
+        }.store(in: &cancellables)
+    }
+
+}
+
+// MARK: - PostCollectionView Delegate
+extension UserInfoViewModel: PostCollectionViewProtocol {
+    
+    func navigateToProfileView(userId: String) {
+        self.outputSubject.send(.navigateToProfileView(userId))
+    }
+    
+    func navigateToReadView(postId: String) {
+        self.outputSubject.send(.navigateToReadView(postId))
     }
 }


### PR DESCRIPTION
## 개요 📖

- #86 
- 재활용이 많은 PostCollectionView를 Common UI 로 빼왔습니다. :)

## 설명 📄

- 재활용이 많은 PostCollectionView를 Common UI 로 빼왔습니다. 
- PostCollectionViewProtocol을 만들고 Generic 타입으로 받아와 사용합니다.


## 고민거리 🤔

### Q. 고민1
reusable 하지만 좋은 코드는 아닌 것 같아요. 이해도 제대로 안되었고, Generic으로 받으니 objc 코드 사용이 불가해서 Gesture 관련 함수를 따로 빼내지 못했어요. static을 사용하지 못해 enum으로 Metrics를 만들어 사용하던 규칙을 지킬 수 없었습니다. cell Identifiler 도 마찬가지입니다.

다른 좋은 방법이 분명 있을 테니 차후 수정이 필요합니다.

## 스크린샷 📷

https://github.com/boostcampwm2023/iOS03-Macro/assets/87685946/9e746bd7-1339-4941-86cd-dcf2faaad454

## Close Issues
#86 

공통 체크 리스트
- [X] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 작업에 맞는 label을 추가했는지 확인
- [X] 컨벤션 지켰는지 확인

iOS 체크 리스트
- [X] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [X] final, private 제대로 넣었는지 확인
- [X] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [X] iPhone SE
  - [X] iPhone 15
  - [X] iPhone 15 Pro Max
