### PR TITLE
[feat][#119] CoreData Table Attribute 변경, 로직 변경

### DIFF
--- a/iOS/Macro/Macro/CoreData/Macro.xcdatamodeld/Model.xcdatamodel/contents
+++ b/iOS/Macro/Macro/CoreData/Macro.xcdatamodeld/Model.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="recordedLocation" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[[Double]]"/>
-        <attribute name="recordedPindedLocation" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[[Double]]"/>
+        <attribute name="recordedPindedLocation" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[[String:[Double]]]"/>
         <attribute name="sequence" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>

--- a/iOS/Macro/Macro/Scene/Travel/Entities/TravelInfo.swift
+++ b/iOS/Macro/Macro/Scene/Travel/Entities/TravelInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 struct TravelInfo {
     let id: String
     var recordedLocation: [[Double]]?
-    var recordedPindedLocation: [[Double]]?
+    var recordedPindedInfo: [[String: [Double?]]]?
     let sequence: Int16
     var startAt: Date?
     var endAt: Date?

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -121,10 +121,10 @@ final class TravelViewModel: ViewModelProtocol {
     }
     
     private func completeTravel() {
-        let transRoute = savedRoute.routePoints.map{[$0.coordinate.latitude, $0.coordinate.longitude]}
-        let pinnedTransROUTE = savedRoute.pinnedPlaces.map{[Double($0.mapx), Double($0.mapy)]}
+        let transRoute = savedRoute.routePoints.map({ [$0.coordinate.latitude, $0.coordinate.longitude] })
+        let pinnedTransRoute = savedRoute.pinnedPlaces.map({ [$0.placeName: [Double($0.mapx), Double($0.mapy)]] })
         self.currentTravel?.recordedLocation = transRoute
-        self.currentTravel?.recordedPindedLocation = transRoute
+        self.currentTravel?.recordedPindedInfo = pinnedTransRoute
         
     }
     
@@ -132,14 +132,14 @@ final class TravelViewModel: ViewModelProtocol {
         let currentTime: Date = Date()
         guard let travel = self.currentTravel,
               let recordedLocation = travel.recordedLocation,
-              let recordedPindedLocation = travel.recordedPindedLocation,
+              let recordedPindedInfo: [[String: [Double?]]] = travel.recordedPindedInfo,
               let startAt = travel.startAt,
               let endAt = travel.endAt
         else { return }
         
         CoreDataManager.shared.saveTravel(id: travel.id,
                                           recordedLocation: recordedLocation,
-                                          recordedPindedLocation: recordedPindedLocation,
+                                          recordedPindedLocation: recordedPindedInfo,
                                           sequence: Int(travel.sequence),
                                           startAt: startAt,
                                           endAt: endAt)

--- a/iOS/Macro/Macro/Util/CoreData/CoreDataManager.swift
+++ b/iOS/Macro/Macro/Util/CoreData/CoreDataManager.swift
@@ -25,7 +25,12 @@ class CoreDataManager {
         }
     }
     
-    func saveTravel(id: String, recordedLocation: [[Double]], recordedPindedLocation: [[Double]], sequence: Int, startAt: Date, endAt: Date) {
+    func saveTravel(id: String,
+                    recordedLocation: [[Double]],
+                    recordedPindedLocation: [[String: [Double?]]],
+                    sequence: Int,
+                    startAt: Date,
+                    endAt: Date) {
         let request = NSFetchRequest<Travel>(entityName: Label.entityName)
         do {
             let locations = try coreDataStack.managedContext.fetch(request)


### PR DESCRIPTION
## 개요 📖

- #119 
- 코어데이터를 기획에 맞게 수정합니다.


## 설명 📄
- 시작, 종료, Sequence, 여행id, 여행Route, PinnedRoute 를 담습니다.
StartAt

<img width="259" alt="image" src="https://github.com/boostcampwm2023/iOS03-Macro/assets/87685946/5a82ce71-7c88-42b6-88d2-0ab87c8667aa">

<img width="391" alt="image" src="https://github.com/boostcampwm2023/iOS03-Macro/assets/87685946/758032d3-1b08-4cae-ba73-53ef3979457b">

## 고민거리 🤔
코어데이터에 파라미터 보낼 때 5개 이하로 넣으라고 되어 있는 데, 6개라서 린트에 걸려요.


## Close Issues 🔒 (닫을 Issue)
Close #119 