### PR TITLE
[feat] home, searchpage api 연결

### DIFF
--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		D21B10092B14799C00F2F84E /* NameEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B10082B14799C00F2F84E /* NameEditView.swift */; };
 		D21B100B2B1497E000F2F84E /* IntroductionEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B100A2B1497E000F2F84E /* IntroductionEditView.swift */; };
 		D21B100E2B16E73200F2F84E /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B100D2B16E73200F2F84E /* UserProfile.swift */; };
+		D21B10102B16FDA000F2F84E /* PostSearchEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B100F2B16FDA000F2F84E /* PostSearchEndPoint.swift */; };
 		D241DC6E2B0D9FFE0037DDB6 /* SearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC6D2B0D9FFE0037DDB6 /* SearchUseCase.swift */; };
 		D241DC712B0DA0070037DDB6 /* CommonUIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC702B0DA0070037DDB6 /* CommonUIComponents.swift */; };
 		D241DC752B0DA00F0037DDB6 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC732B0DA00F0037DDB6 /* Writer.swift */; };
@@ -213,6 +214,7 @@
 		D21B10082B14799C00F2F84E /* NameEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameEditView.swift; sourceTree = "<group>"; };
 		D21B100A2B1497E000F2F84E /* IntroductionEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionEditView.swift; sourceTree = "<group>"; };
 		D21B100D2B16E73200F2F84E /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
+		D21B100F2B16FDA000F2F84E /* PostSearchEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchEndPoint.swift; sourceTree = "<group>"; };
 		D241DC6D2B0D9FFE0037DDB6 /* SearchUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchUseCase.swift; sourceTree = "<group>"; };
 		D241DC702B0DA0070037DDB6 /* CommonUIComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommonUIComponents.swift; sourceTree = "<group>"; };
 		D241DC732B0DA00F0037DDB6 /* Writer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
@@ -873,6 +875,7 @@
 			children = (
 				BA90CB9D2B145CDE00365AE2 /* FollowEndPoint.swift */,
 				BA90CBA72B147E1900365AE2 /* UserInfoEndPoint.swift */,
+				D21B100F2B16FDA000F2F84E /* PostSearchEndPoint.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1226,6 +1229,7 @@
 				AAD0B2E52B103555003B4D5F /* WriteRequestDTO.swift in Sources */,
 				AA46C4B82B02304400856628 /* AppDelegate.swift in Sources */,
 				BA6C6DF92B05FFC500563B22 /* TabBarCenterView.swift in Sources */,
+				D21B10102B16FDA000F2F84E /* PostSearchEndPoint.swift in Sources */,
 				BA90CB9E2B145CDE00365AE2 /* FollowEndPoint.swift in Sources */,
 				BA6C6DF42B05FFC500563B22 /* CircularViewProtocol.swift in Sources */,
 				BA90CB982B1450A200365AE2 /* UserInfoProfileView.swift in Sources */,

--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		D21B10072B14660600F2F84E /* MyInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B10062B14660600F2F84E /* MyInfoViewController.swift */; };
 		D21B10092B14799C00F2F84E /* NameEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B10082B14799C00F2F84E /* NameEditView.swift */; };
 		D21B100B2B1497E000F2F84E /* IntroductionEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B100A2B1497E000F2F84E /* IntroductionEditView.swift */; };
+		D21B100E2B16E73200F2F84E /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21B100D2B16E73200F2F84E /* UserProfile.swift */; };
 		D241DC6E2B0D9FFE0037DDB6 /* SearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC6D2B0D9FFE0037DDB6 /* SearchUseCase.swift */; };
 		D241DC712B0DA0070037DDB6 /* CommonUIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC702B0DA0070037DDB6 /* CommonUIComponents.swift */; };
 		D241DC752B0DA00F0037DDB6 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D241DC732B0DA00F0037DDB6 /* Writer.swift */; };
@@ -211,6 +212,7 @@
 		D21B10062B14660600F2F84E /* MyInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoViewController.swift; sourceTree = "<group>"; };
 		D21B10082B14799C00F2F84E /* NameEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameEditView.swift; sourceTree = "<group>"; };
 		D21B100A2B1497E000F2F84E /* IntroductionEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionEditView.swift; sourceTree = "<group>"; };
+		D21B100D2B16E73200F2F84E /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
 		D241DC6D2B0D9FFE0037DDB6 /* SearchUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchUseCase.swift; sourceTree = "<group>"; };
 		D241DC702B0DA0070037DDB6 /* CommonUIComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommonUIComponents.swift; sourceTree = "<group>"; };
 		D241DC732B0DA00F0037DDB6 /* Writer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
@@ -657,6 +659,7 @@
 		BA6C6DE52B05FFC500563B22 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				D21B100C2B16DDF200F2F84E /* Network */,
 				D241DC722B0DA00F0037DDB6 /* Entities */,
 				D241DC6F2B0DA0070037DDB6 /* UI */,
 				D241DC6C2B0D9FFE0037DDB6 /* UseCases */,
@@ -935,6 +938,13 @@
 			path = NetworkUnresearchable;
 			sourceTree = "<group>";
 		};
+		D21B100C2B16DDF200F2F84E /* Network */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		D241DC6C2B0D9FFE0037DDB6 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
@@ -961,6 +971,7 @@
 				D241DC732B0DA00F0037DDB6 /* Writer.swift */,
 				D241DC742B0DA00F0037DDB6 /* PostFindResponse.swift */,
 				BAB24EDA2B1633B2000991A1 /* ProfileGetResponse.swift */,
+				D21B100D2B16E73200F2F84E /* UserProfile.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1188,6 +1199,7 @@
 				AAD0B3002B147CA3003B4D5F /* RefreshTokenResponse.swift in Sources */,
 				AAD0B3022B147CCC003B4D5F /* RefreshTokenEndPoint.swift in Sources */,
 				D263CA222B040EBE00B4A144 /* TravelViewModel.swift in Sources */,
+				D21B100E2B16E73200F2F84E /* UserProfile.swift in Sources */,
 				AAD0B3162B14E394003B4D5F /* ReadPostUseCase.swift in Sources */,
 				BA8DC40A2B0B5F7800929E01 /* TabViewController.swift in Sources */,
 				D241DC762B0DA00F0037DDB6 /* PostFindResponse.swift in Sources */,

--- a/iOS/Macro/Macro/Common/CommonProtocol/PostCollectionViewProtocol.swift
+++ b/iOS/Macro/Macro/Common/CommonProtocol/PostCollectionViewProtocol.swift
@@ -11,7 +11,7 @@ import UIKit
 protocol PostCollectionViewProtocol: AnyObject {
     var posts: [PostFindResponse] { get set }
     
-    func navigateToProfileView(userId: String)
+    func navigateToProfileView(email: String)
     func navigateToReadView(postId: Int)
     func loadImage(profileImageStringURL: String, completion: @escaping (UIImage?) -> Void)
     func touchLike(postId: String, compeletion: @escaping (Bool) -> Void)

--- a/iOS/Macro/Macro/Common/Entities/ProfileGetResponse.swift
+++ b/iOS/Macro/Macro/Common/Entities/ProfileGetResponse.swift
@@ -10,8 +10,8 @@ import Foundation
 struct ProfileGetResponse: Codable {
     let userId: String
     let name: String
-    let imageUrl: String
-    let introduce: String
+    let imageUrl: String?
+    let introduce: String?
     let following: Bool
     let follower: Bool
     let followersNum: Int

--- a/iOS/Macro/Macro/Common/Entities/UserProfile.swift
+++ b/iOS/Macro/Macro/Common/Entities/UserProfile.swift
@@ -1,0 +1,17 @@
+//
+//  UserProfile.swift
+//  Macro
+//
+//  Created by 김나훈 on 11/29/23.
+//
+
+import Foundation
+
+struct UserProfile: Codable {
+    let email: String
+    let name: String
+    let imageUrl: String?
+    let introduce: String?
+    let followersNum: Int
+    let followeesNum: Int
+}

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
@@ -43,17 +43,12 @@ final class PostCollectionView<T: PostCollectionViewProtocol>: UICollectionView,
         return viewModel.posts.count
     }
     
-    func collectionView(_ collectionView: UICollectionView,
-                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: "PostCollectionViewCell",
-            for: indexPath) as? PostCollectionViewCell<T> else { return UICollectionViewCell()
-        }
-        let item: PostFindResponse = viewModel.posts[indexPath.row]
-        cell.configure(item: item, viewModel: viewModel)
-        
-        return cell
-    }
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+           guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "PostCollectionViewCell", for: indexPath) as? PostCollectionViewCell<T> else { return UICollectionViewCell() }
+           let item = viewModel.posts[indexPath.row]
+           cell.configure(item: item, viewModel: viewModel, indexPath: indexPath)
+           return cell
+       }
     
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
@@ -75,6 +75,8 @@ private extension PostCollectionViewCell {
 extension PostCollectionViewCell {
     
     func configure(item: PostFindResponse, viewModel: T, indexPath: IndexPath) {
+        postProfileView.configure(item: item)
+        postContentView.configure(item: item)
         postProfileView.indexPath = indexPath
         setTranslatesAutoresizingMaskIntoConstraints()
         addsubviews()

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
@@ -74,10 +74,12 @@ private extension PostCollectionViewCell {
 
 extension PostCollectionViewCell {
     
-    func configure(item: PostFindResponse, viewModel: T) {
+    func configure(item: PostFindResponse, viewModel: T, indexPath: IndexPath) {
+        postProfileView.indexPath = indexPath
         setTranslatesAutoresizingMaskIntoConstraints()
         addsubviews()
         setLayoutConstraints()
         componetConfigure(item: item, viewModel: viewModel)
     }
+
 }

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
@@ -23,7 +23,7 @@ final class PostProfileView<T: PostCollectionViewProtocol>: UIView {
         return label
     }()
     
-    private let userNameLabel: UILabel = {
+    var userNameLabel: UILabel = {
         let label: UILabel = UILabel()
         label.textColor = UIColor.appColor(.purple5)
         label.font = UIFont.appFont(.baeEunBody)
@@ -76,7 +76,7 @@ final class PostProfileView<T: PostCollectionViewProtocol>: UIView {
         if let indexPath = indexPath {
             guard let email = viewModel?.posts[indexPath.row].writer.email else { return }
             viewModel?.navigateToProfileView(email: email)
-            print(email)
+
         }
         
     }

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
@@ -13,7 +13,7 @@ final class PostProfileView<T: PostCollectionViewProtocol>: UIView {
     // MARK: - Properties
     private var cancellables = Set<AnyCancellable>()
     var viewModel: T?
-    
+    var indexPath: IndexPath?
     // MARK: - UI Components
     
     private let viewCountLabel: UILabel = {
@@ -73,9 +73,14 @@ final class PostProfileView<T: PostCollectionViewProtocol>: UIView {
     // MARK: - Handle Gesture
     
     @objc private func profileImageTap(_ sender: UITapGestureRecognizer) {
-        guard let userId: String = self.userNameLabel.text else { return }
-        viewModel?.navigateToProfileView(userId: userId)
+        if let indexPath = indexPath {
+            guard let email = viewModel?.posts[indexPath.row].writer.email else { return }
+            viewModel?.navigateToProfileView(email: email)
+            print(email)
+        }
+        
     }
+    
     
     @objc private func likeImageViewTap(_ sender: UITapGestureRecognizer) {
         guard let likeCount: Int = Int(self.likeCountLabel.text ?? "0") else { return }

--- a/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
+++ b/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
@@ -30,10 +30,13 @@ protocol SearchUseCase {
     
     /// 특정 사용자의 id를 검색하면, 해당 json 파일 내의 해당 사용자의 게시글 모두 불러옴
     func searchMockUserProfile(query: String, json: String) -> AnyPublisher<ProfileGetResponse, NetworkError>
+
+    /// 특정 제목으로 게시글을 검색
+    func searchPostTitle(query: String) -> AnyPublisher<[PostFindResponse], NetworkError>
 }
 
 final class Searcher: SearchUseCase {
-   
+    
     // MARK: - Properties
     
     private let provider: Requestable
@@ -72,5 +75,9 @@ final class Searcher: SearchUseCase {
     
     func searchMockUserProfile(query: String, json: String) -> AnyPublisher<ProfileGetResponse, MacroNetwork.NetworkError> {
         return provider.mockRequest(UserInfoEndPoint.search(query), url: json)
+    }
+    
+    func searchPostTitle(query: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
+        return provider.request(PostFindEndPoint.search(query))
     }
 }

--- a/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
+++ b/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
@@ -13,7 +13,7 @@ protocol SearchUseCase {
     /// 특정 장소를 검색했을 때 받아오는 검색 결과
     func searchLocation(query: String, page: Int) -> AnyPublisher<[LocationDetail], NetworkError>
     
-    /// 특정 검색어가 제목에 포함되었는지를 검색하는 결과
+    /// 특정 사용자의 게시글들을 전부 불러오는 함수
     func searchPost(query: String) -> AnyPublisher<[PostFindResponse], NetworkError>
     
     /// 특정 검색어가 해당 json 파일 list의 제목에 포함되는지 검색
@@ -25,8 +25,8 @@ protocol SearchUseCase {
     /// 홈 화면의 게시글들을 해당 json 파일에서 모두 불러오는 작업
     func searchMockPost(json: String) -> AnyPublisher<[PostFindResponse], NetworkError>
     
-    /// 특정 사용자의 id를 검색하면, 해당 사용자의 게시글들을 모두 불러옴
-    func searchUserProfile(query: String) -> AnyPublisher<ProfileGetResponse, NetworkError>
+    /// 특정 사용자의 id를 검색하면, 해당 사용자의 정보를 불러옴
+    func searchUserProfile(query: String) -> AnyPublisher<UserProfile, NetworkError>
     
     /// 특정 사용자의 id를 검색하면, 해당 json 파일 내의 해당 사용자의 게시글 모두 불러옴
     func searchMockUserProfile(query: String, json: String) -> AnyPublisher<ProfileGetResponse, NetworkError>
@@ -51,12 +51,13 @@ final class Searcher: SearchUseCase {
     }
     
     func searchPost(query: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
-        return provider.request(PostFindEndPoint.search(query))
+        return provider.request(PostSearchEndPoint.search(query))
     }
     
     func searchMockPost(query: String, json: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
         return provider.mockRequest(PostFindEndPoint.search(query), url: json)
     }
+    
     func fetchHitPost() -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
         return provider.request(PostEndPoint.search)
     }
@@ -65,7 +66,7 @@ final class Searcher: SearchUseCase {
         return provider.mockRequest(PostEndPoint.search, url: json)
     }
     
-    func searchUserProfile(query: String) -> AnyPublisher<ProfileGetResponse, MacroNetwork.NetworkError> {
+    func searchUserProfile(query: String) -> AnyPublisher<UserProfile, MacroNetwork.NetworkError> {
         return provider.request(UserInfoEndPoint.search(query))
     }
     

--- a/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
+++ b/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
@@ -10,12 +10,25 @@ import Foundation
 import MacroNetwork
 
 protocol SearchUseCase {
+    /// 특정 장소를 검색했을 때 받아오는 검색 결과
     func searchLocation(query: String, page: Int) -> AnyPublisher<[LocationDetail], NetworkError>
+    
+    /// 특정 검색어가 제목에 포함되었는지를 검색하는 결과
     func searchPost(query: String) -> AnyPublisher<[PostFindResponse], NetworkError>
+    
+    /// 특정 검색어가 해당 json 파일 list의 제목에 포함되는지 검색
     func searchMockPost(query: String, json: String) -> AnyPublisher<[PostFindResponse], NetworkError>
+    
+    /// 가장 인기있는 게시물들을 받아오는 작업
     func fetchHitPost() -> AnyPublisher<[PostFindResponse], NetworkError>
+    
+    /// 홈 화면의 게시글들을 해당 json 파일에서 모두 불러오는 작업
     func searchMockPost(json: String) -> AnyPublisher<[PostFindResponse], NetworkError>
-    func searchUser(query: String) -> AnyPublisher<ProfileGetResponse, NetworkError>
+    
+    /// 특정 사용자의 id를 검색하면, 해당 사용자의 게시글들을 모두 불러옴
+    func searchUserProfile(query: String) -> AnyPublisher<ProfileGetResponse, NetworkError>
+    
+    /// 특정 사용자의 id를 검색하면, 해당 json 파일 내의 해당 사용자의 게시글 모두 불러옴
     func searchMockUserProfile(query: String, json: String) -> AnyPublisher<ProfileGetResponse, NetworkError>
 }
 
@@ -52,7 +65,7 @@ final class Searcher: SearchUseCase {
         return provider.mockRequest(PostEndPoint.search, url: json)
     }
     
-    func searchUser(query: String) -> AnyPublisher<ProfileGetResponse, MacroNetwork.NetworkError> {
+    func searchUserProfile(query: String) -> AnyPublisher<ProfileGetResponse, MacroNetwork.NetworkError> {
         return provider.request(UserInfoEndPoint.search(query))
     }
     

--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
@@ -95,9 +95,9 @@ private extension HomeViewController {
         homeCollectionView.reloadData()
     }
     
-    func navigateToProfileView(_ userId: String) {
+    func navigateToProfileView(_ email: String) {
         let userInfoViewModel = UserInfoViewModel(postSearcher: viewModel.postSearcher, followFeature: viewModel.followFeatrue)
-        let userInfoViewController = UserInfoViewController(viewModel: userInfoViewModel, userInfo: userId)
+        let userInfoViewController = UserInfoViewController(viewModel: userInfoViewModel, userInfo: email)
 
         navigationController?.pushViewController(userInfoViewController, animated: true)
     }
@@ -118,8 +118,8 @@ private extension HomeViewController {
             switch output {
             case let .updateSearchResult(result):
                 self?.updateSearchResult(result)
-            case let .navigateToProfileView(userId):
-                self?.navigateToProfileView(userId)
+            case let .navigateToProfileView(email):
+                self?.navigateToProfileView(email)
             case let .navigateToReadView(postId):
                 self?.navigateToReadView(postId)
             default: break

--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/ViewModel/HomeViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/ViewModel/HomeViewModel.swift
@@ -10,27 +10,6 @@ import Foundation
 
 final class HomeViewModel: ViewModelProtocol, PostCollectionViewProtocol {
     
-    func navigateToReadView(postId: Int) {
-        self.outputSubject.send(.navigateToReadView(postId))
-    }
-    
-    func navigateToProfileView(email: String) {
-        self.outputSubject.send(.navigateToProfileView(email))
-    }
-
-    func searchUser(with input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { [weak self] input in
-            switch input {
-            case .searchPosts:
-              self?.searchPosts()
-            case .searchMockPost:
-                self?.searchMockPost()
-            }
-        }.store(in: &cancellables)
-        
-        return outputSubject.eraseToAnyPublisher()
-    }
-    
     // MARK: - Input
     
     enum Input {
@@ -98,4 +77,13 @@ final class HomeViewModel: ViewModelProtocol, PostCollectionViewProtocol {
     private func searchPost(postId: Int) {
         self.outputSubject.send(.navigateToReadView(postId))
     }
+    
+    func navigateToReadView(postId: Int) {
+        self.outputSubject.send(.navigateToReadView(postId))
+    }
+    
+    func navigateToProfileView(email: String) {
+        self.outputSubject.send(.navigateToProfileView(email))
+    }
+
 }

--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/ViewModel/HomeViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/ViewModel/HomeViewModel.swift
@@ -14,8 +14,8 @@ final class HomeViewModel: ViewModelProtocol, PostCollectionViewProtocol {
         self.outputSubject.send(.navigateToReadView(postId))
     }
     
-    func navigateToProfileView(userId: String) {
-        self.outputSubject.send(.navigateToProfileView(userId))
+    func navigateToProfileView(email: String) {
+        self.outputSubject.send(.navigateToProfileView(email))
     }
 
     func searchUser(with input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {

--- a/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
@@ -153,7 +153,7 @@ extension LocationInfoViewController {
         placeNameLabel.text = model.placeName.isEmpty == true ? "-" : model.placeName
         addressLabel.text = model.addressName.isEmpty == true ? "-" : model.addressName
         categoryNameLabel.text = model.categoryName.isEmpty == true ? "-" : model.categoryName
-        categoryGroupLabel.text = model.categoryGroupName.isEmpty == true ? "-" : model.categoryGroupName
+        categoryGroupLabel.text = model.categoryGroupName.isEmpty == true ? "-" : "(\(model.categoryGroupName))"
         phoneLabel.text = model.phone?.isEmpty == true ? "-" : (model.phone ?? "-")
     }
 }

--- a/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
@@ -62,6 +62,16 @@ final class LocationInfoViewController: UIViewController {
         return label
     }()
     
+    private let segmentControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: ["포함된 여행", "함께 많이 간 장소"])
+        control.selectedSegmentIndex = 0
+        control.tintColor = UIColor.appColor(.purple2)
+        let font = UIFont.appFont(.baeEunBody)
+        let normalTextColor = UIColor.appColor(.purple5)
+        control.setTitleTextAttributes([.font: font, .foregroundColor: normalTextColor], for: .normal)
+        return control
+    }()
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -86,6 +96,7 @@ extension LocationInfoViewController {
         categoryGroupLabel.translatesAutoresizingMaskIntoConstraints = false
         phoneLabel.translatesAutoresizingMaskIntoConstraints = false
         pinLabel.translatesAutoresizingMaskIntoConstraints = false
+        segmentControl.translatesAutoresizingMaskIntoConstraints = false
     }
     private func addsubviews() {
         view.addSubview(placeNameLabel)
@@ -94,6 +105,7 @@ extension LocationInfoViewController {
         view.addSubview(categoryGroupLabel)
         view.addSubview(phoneLabel)
         view.addSubview(pinLabel)
+        view.addSubview(segmentControl)
     }
     
     private func setLayoutConstraints() {
@@ -109,8 +121,9 @@ extension LocationInfoViewController {
             phoneLabel.topAnchor.constraint(equalTo: categoryGroupLabel.bottomAnchor, constant: Padding.phoneTop),
             phoneLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.labelSide),
             pinLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Padding.pinSide),
-            pinLabel.centerYAnchor.constraint(equalTo: placeNameLabel.centerYAnchor)
-                   
+            pinLabel.centerYAnchor.constraint(equalTo: placeNameLabel.centerYAnchor),
+            segmentControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            segmentControl.topAnchor.constraint(equalTo: phoneLabel.bottomAnchor, constant: Padding.segmentTop)
         ])
         
     }
@@ -142,7 +155,6 @@ extension LocationInfoViewController {
         categoryNameLabel.text = model.categoryName.isEmpty == true ? "-" : model.categoryName
         categoryGroupLabel.text = model.categoryGroupName.isEmpty == true ? "-" : model.categoryGroupName
         phoneLabel.text = model.phone?.isEmpty == true ? "-" : (model.phone ?? "-")
-        print(categoryNameLabel)
     }
 }
 // MARK: - LayoutMetrics
@@ -159,5 +171,6 @@ extension LocationInfoViewController {
         static let phoneTop: CGFloat = 10
         static let labelSide: CGFloat = 50
         static let pinSide: CGFloat = 28
+        static let segmentTop: CGFloat = 18
     }
 }

--- a/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김나훈 on 11/22/23.
 //
 
+import MacroDesignSystem
 import UIKit
 
 final class LocationInfoViewController: UIViewController {
@@ -15,34 +16,50 @@ final class LocationInfoViewController: UIViewController {
     
     private let placeNameLabel: UILabel = {
         let label = UILabel()
+        label.font = UIFont.appFont(.baeEunLargeTitle)
+        label.textColor = UIColor.appColor(.blue4)
+        return label
+    }()
+    
+    private let pinLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.appFont(.baeEunLargeTitle)
+        let symbolImage = UIImage.appImage(.pinFill)?.withTintColor(UIColor.appColor(.purple3))
+        let attachment = NSTextAttachment()
+        attachment.image = symbolImage
+        let attachmentString = NSAttributedString(attachment: attachment)
+        let mutableAttributedString = NSMutableAttributedString(string: " ")
+        mutableAttributedString.append(attachmentString)
+        label.attributedText = mutableAttributedString
         return label
     }()
     
     private let addressLabel: UILabel = {
         let label = UILabel()
+        label.font = UIFont.appFont(.baeEunTitle1)
+        label.textColor = UIColor.appColor(.blue4)
         return label
     }()
     
     private let categoryNameLabel: UILabel = {
         let label = UILabel()
+        label.font = UIFont.appFont(.baeEunBody)
+        label.textColor = UIColor.appColor(.purple3)
         return label
     }()
     
     private let categoryGroupLabel: UILabel = {
         let label = UILabel()
+        label.font = UIFont.appFont(.baeEunCaption)
+        label.textColor = UIColor.appColor(.purple3)
         return label
     }()
     
     private let phoneLabel: UILabel = {
         let label = UILabel()
+        label.font = UIFont.appFont(.baeEunCallout)
+        label.textColor = UIColor.appColor(.blue4)
         return label
-    }()
-
-    private let verticalStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.spacing = 10
-        stackView.axis = .vertical
-        return stackView
     }()
     
     // MARK: - Life Cycle
@@ -63,20 +80,37 @@ final class LocationInfoViewController: UIViewController {
 extension LocationInfoViewController {
     
     private func setTranslatesAutoresizingMaskIntoConstraints() {
-        verticalStackView.translatesAutoresizingMaskIntoConstraints = false
+        placeNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        addressLabel.translatesAutoresizingMaskIntoConstraints = false
+        categoryNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        categoryGroupLabel.translatesAutoresizingMaskIntoConstraints = false
+        phoneLabel.translatesAutoresizingMaskIntoConstraints = false
+        pinLabel.translatesAutoresizingMaskIntoConstraints = false
     }
     private func addsubviews() {
-        view.addSubview(verticalStackView)
-        [placeNameLabel, addressLabel, categoryNameLabel, categoryGroupLabel, phoneLabel].forEach {
-            verticalStackView.addArrangedSubview($0)
-        }
+        view.addSubview(placeNameLabel)
+        view.addSubview(addressLabel)
+        view.addSubview(categoryNameLabel)
+        view.addSubview(categoryGroupLabel)
+        view.addSubview(phoneLabel)
+        view.addSubview(pinLabel)
     }
     
     private func setLayoutConstraints() {
         NSLayoutConstraint.activate([
-            verticalStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 25),
-            verticalStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 32),
-            verticalStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -32)
+            placeNameLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Padding.nameTop),
+            placeNameLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.labelSide),
+            addressLabel.topAnchor.constraint(equalTo: placeNameLabel.bottomAnchor, constant: Padding.addressTop),
+            addressLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.labelSide),
+            categoryNameLabel.topAnchor.constraint(equalTo: addressLabel.bottomAnchor, constant: Padding.categoryNameTop),
+            categoryNameLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.labelSide),
+            categoryGroupLabel.topAnchor.constraint(equalTo: categoryNameLabel.bottomAnchor, constant: Padding.categoryGroupTop),
+            categoryGroupLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.labelSide),
+            phoneLabel.topAnchor.constraint(equalTo: categoryGroupLabel.bottomAnchor, constant: Padding.phoneTop),
+            phoneLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.labelSide),
+            pinLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Padding.pinSide),
+            pinLabel.centerYAnchor.constraint(equalTo: placeNameLabel.centerYAnchor)
+                   
         ])
         
     }
@@ -103,16 +137,27 @@ extension LocationInfoViewController {
 
 extension LocationInfoViewController {
     func updateText(_ model: LocationDetail) {
-        placeNameLabel.text = "가게 정보: " + model.placeName
-        addressLabel.text = "주소: " + model.addressName
-        categoryNameLabel.text = "종류: " + model.categoryName
-        categoryGroupLabel.text = "분류: " + model.categoryGroupName
-        phoneLabel.text = "전화번호: " + (model.phone?.isEmpty == true ? "-" : (model.phone ?? "-"))
+        placeNameLabel.text = model.placeName.isEmpty == true ? "-" : model.placeName
+        addressLabel.text = model.addressName.isEmpty == true ? "-" : model.addressName
+        categoryNameLabel.text = model.categoryName.isEmpty == true ? "-" : model.categoryName
+        categoryGroupLabel.text = model.categoryGroupName.isEmpty == true ? "-" : model.categoryGroupName
+        phoneLabel.text = model.phone?.isEmpty == true ? "-" : (model.phone ?? "-")
+        print(categoryNameLabel)
     }
 }
-
 // MARK: - LayoutMetrics
 
 extension LocationInfoViewController {
-    
+    enum Metrics {
+        
+    }
+    enum Padding {
+        static let nameTop: CGFloat = 20
+        static let addressTop: CGFloat = 20
+        static let categoryNameTop: CGFloat = 10
+        static let categoryGroupTop: CGFloat = 0
+        static let phoneTop: CGFloat = 10
+        static let labelSide: CGFloat = 50
+        static let pinSide: CGFloat = 28
+    }
 }

--- a/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyPageViewController.swift
+++ b/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyPageViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Byeon jinha on 11/21/23.
 //
 
+import MacroNetwork
 import UIKit
 
 final class MyPageViewController: TabViewController {
@@ -109,7 +110,9 @@ extension MyPageViewController {
         addsubviews()
         setLayoutConstraints()
     }
-    
+    @objc func backButtonPressed() {
+        self.dismiss(animated: true, completion: nil)
+    }
 }
 
 // MARK: - Methods
@@ -188,7 +191,16 @@ extension MyPageViewController: UITableViewDelegate, UITableViewDataSource {
         else if indexPath.section == 0 && indexPath.row == 1 {
             presentImagePickerController()
         }
-       
+        else if indexPath.section == 1 && indexPath.row == 0 {
+            let provider = APIProvider(session: URLSession.shared)
+            let userInfoViewModel = UserInfoViewModel(postSearcher: Searcher(provider: provider), followFeature: FollowFeature(provider: provider))
+            let userInfoVC = UserInfoViewController(viewModel: userInfoViewModel, userInfo: "SomeUserInfo")
+            self.navigationController?.pushViewController(userInfoVC, animated: true)
+        }
+        else if indexPath.section == 1 && indexPath.row == 1 {
+            
+        }
+        
     }
 }
 

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
@@ -5,10 +5,65 @@
 //  Created by Byeon jinha on 11/20/23.
 //
 
-import Foundation
+import Combine
+import UIKit
+
 
 final class SearchViewController: TabViewController {
+    
+    // MARK: - Properties
+    
     let viewModel: SearchViewModel
+    private var cancellables = Set<AnyCancellable>()
+    private let inputSubject: PassthroughSubject<SearchViewModel.Input, Never> = .init()
+    
+    // MARK: - UI Components
+    
+    private let searchBar: UITextField = CommonUIComponents.createSearchBar()
+    
+    private let searchSegment: UISegmentedControl = {
+        let segmentItems = ["계정", "글"]
+        let segmentControl = UISegmentedControl(items: segmentItems)
+        segmentControl.selectedSegmentIndex = 0
+        let accountImage = UIImage.appImage(.person2Fill) ?? UIImage()
+        let postImage = UIImage.appImage(.chartBarDocHorizontal) ?? UIImage()
+        let font = UIFont.appFont(.baeEunBody)
+        let color = UIColor.appColor(.purple5)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color
+        ]
+
+        for (index, text) in segmentItems.enumerated() {
+            let icon = index == 0 ? accountImage : postImage
+            let textSize = (text as NSString).size(withAttributes: attributes)
+            let textRect = CGRect(origin: CGPoint.zero, size: textSize)
+            let iconRect = CGRect(origin: CGPoint(x: textRect.maxX + 5, y: (textSize.height - icon.size.height) / 2), size: icon.size)
+            let imageSize = CGSize(width: iconRect.maxX, height: max(textRect.height, icon.size.height))
+
+            UIGraphicsBeginImageContextWithOptions(imageSize, false, 0)
+            text.draw(in: textRect, withAttributes: attributes)
+            icon.draw(in: iconRect)
+            let combinedImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+
+            segmentControl.setImage(combinedImage, forSegmentAt: index)
+        }
+
+        return segmentControl
+    }()
+
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setUpLayout()
+        bind()
+        searchSegment.addTarget(self, action: #selector(segmentValueChanged(_:)), for: .valueChanged)
+        searchBar.addTarget(self, action: #selector(searchBarReturnPressed), for: .editingDidEndOnExit)
+    }
     
     init(viewModel: SearchViewModel) {
         self.viewModel = viewModel
@@ -19,4 +74,88 @@ final class SearchViewController: TabViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+}
+
+// MARK: - UI Settings
+extension SearchViewController {
+    private func setTranslatesAutoresizingMaskIntoConstraints() {
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        searchSegment.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    private func addsubviews() {
+        view.addSubview(searchBar)
+        view.addSubview(searchSegment)
+    }
+    
+    private func setLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Padding.segmentTop),
+            searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.searchSide),
+            searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Padding.searchSide),
+            searchBar.heightAnchor.constraint(equalToConstant: Metrics.searchBarHeight),
+            searchSegment.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: Padding.segmentTop),
+            searchSegment.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            searchSegment.heightAnchor.constraint(equalToConstant: Metrics.segmentHeight),
+            searchSegment.widthAnchor.constraint(equalToConstant: Metrics.segmentWidth)
+        ])
+        
+    }
+}
+
+extension SearchViewController {
+    
+    private func setUpLayout() {
+        setTranslatesAutoresizingMaskIntoConstraints()
+        addsubviews()
+        setLayoutConstraints()
+    }
+    
+}
+
+// MARK: - Bind
+extension SearchViewController {
+    private func bind() {
+        let outputSubject = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
+        
+        outputSubject.receive(on: RunLoop.main).sink { [weak self] output in
+            switch output {
+            case let .updateSearchResult(result):
+                self?.updateSearchResult(result)
+            }
+        }.store(in: &cancellables)
+        
+    }
+}
+
+// MARK: - Methods
+extension SearchViewController {
+    @objc private func segmentValueChanged(_ sender: UISegmentedControl) {
+        let selectedType = sender.selectedSegmentIndex == 0 ? SearchType.account : SearchType.post
+        inputSubject.send(.changeSelectType(selectedType))
+    }
+    
+    @objc private func searchBarReturnPressed() {
+        let text = searchBar.text ?? ""
+        inputSubject.send(.search(text))
+    }
+    
+    func updateSearchResult(_ result: [PostFindResponse]) {
+      
+    }
+}
+
+// MARK: - LayoutMetrics
+extension SearchViewController {
+    enum Metrics {
+        static let searchBarHeight: CGFloat = 43
+        static let segmentHeight: CGFloat = 34
+        static let segmentWidth: CGFloat = 222
+    }
+    
+    enum Padding {
+        static let seachBarTop: CGFloat = 10
+        static let segmentTop: CGFloat = 20
+        static let searchSide: CGFloat = 10
+    }
 }

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
@@ -21,6 +21,8 @@ final class SearchViewController: TabViewController {
     
     private let searchBar: UITextField = CommonUIComponents.createSearchBar()
     
+    lazy var postCollectionView: PostCollectionView = PostCollectionView(frame: .zero, viewModel: viewModel)
+    
     private let searchSegment: UISegmentedControl = {
         let segmentItems = ["계정", "글"]
         let segmentControl = UISegmentedControl(items: segmentItems)
@@ -33,27 +35,22 @@ final class SearchViewController: TabViewController {
             .font: font,
             .foregroundColor: color
         ]
-
         for (index, text) in segmentItems.enumerated() {
             let icon = index == 0 ? accountImage : postImage
             let textSize = (text as NSString).size(withAttributes: attributes)
             let textRect = CGRect(origin: CGPoint.zero, size: textSize)
             let iconRect = CGRect(origin: CGPoint(x: textRect.maxX + 5, y: (textSize.height - icon.size.height) / 2), size: icon.size)
             let imageSize = CGSize(width: iconRect.maxX, height: max(textRect.height, icon.size.height))
-
             UIGraphicsBeginImageContextWithOptions(imageSize, false, 0)
             text.draw(in: textRect, withAttributes: attributes)
             icon.draw(in: iconRect)
             let combinedImage = UIGraphicsGetImageFromCurrentImageContext()
             UIGraphicsEndImageContext()
-
             segmentControl.setImage(combinedImage, forSegmentAt: index)
         }
-
         return segmentControl
     }()
 
-    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -81,11 +78,13 @@ extension SearchViewController {
     private func setTranslatesAutoresizingMaskIntoConstraints() {
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         searchSegment.translatesAutoresizingMaskIntoConstraints = false
+        postCollectionView.translatesAutoresizingMaskIntoConstraints = false
     }
     
     private func addsubviews() {
         view.addSubview(searchBar)
         view.addSubview(searchSegment)
+        view.addSubview(postCollectionView)
     }
     
     private func setLayoutConstraints() {
@@ -97,9 +96,12 @@ extension SearchViewController {
             searchSegment.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: Padding.segmentTop),
             searchSegment.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             searchSegment.heightAnchor.constraint(equalToConstant: Metrics.segmentHeight),
-            searchSegment.widthAnchor.constraint(equalToConstant: Metrics.segmentWidth)
+            searchSegment.widthAnchor.constraint(equalToConstant: Metrics.segmentWidth),
+            postCollectionView.topAnchor.constraint(equalTo: searchSegment.bottomAnchor, constant: Padding.postCollectionViewTop),
+            postCollectionView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            postCollectionView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            postCollectionView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
         ])
-        
     }
 }
 
@@ -122,6 +124,10 @@ extension SearchViewController {
             switch output {
             case let .updateSearchResult(result):
                 self?.updateSearchResult(result)
+            case .navigateToProfileView(_):
+                print(1)
+            case .navigateToReadView(_):
+                print(2)
             }
         }.store(in: &cancellables)
         
@@ -141,7 +147,8 @@ extension SearchViewController {
     }
     
     func updateSearchResult(_ result: [PostFindResponse]) {
-      
+        postCollectionView.viewModel.posts = result
+        postCollectionView.reloadData()
     }
 }
 
@@ -157,5 +164,6 @@ extension SearchViewController {
         static let seachBarTop: CGFloat = 10
         static let segmentTop: CGFloat = 20
         static let searchSide: CGFloat = 10
+        static let postCollectionViewTop: CGFloat = 10
     }
 }

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
@@ -124,7 +124,7 @@ extension SearchViewController {
             switch output {
             case let .updateSearchResult(result):
                 self?.updateSearchResult(result)
-            case .navigateToProfileView(_):
+            case let .navigateToProfileView(userId):
                 print(1)
             case .navigateToReadView(_):
                 print(2)
@@ -149,6 +149,21 @@ extension SearchViewController {
     func updateSearchResult(_ result: [PostFindResponse]) {
         postCollectionView.viewModel.posts = result
         postCollectionView.reloadData()
+    }
+    func navigateToProfileView(_ userId: String) {
+//        let userInfoViewModel = UserInfoViewModel(postSearcher: viewModel.postSearcher, followFeature: viewModel.followFeatrue)
+//        let userInfoViewController = UserInfoViewController(viewModel: userInfoViewModel, userInfo: userId)
+//
+//        navigationController?.pushViewController(userInfoViewController, animated: true)
+    }
+    
+    func navigateToReadView(_ postId: Int) {
+//        let provider = APIProvider(session: URLSession.shared)
+//        let readuseCase = ReadPostUseCase(provider: provider)
+//        let readViewModel = ReadViewModel(useCase: readuseCase, postId: postId)
+//        let readViewController = ReadViewController(viewModel: readViewModel)
+//
+//        navigationController?.pushViewController(readViewController, animated: true)
     }
 }
 

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
@@ -71,7 +71,7 @@ extension SearchViewModel {
     }
     
     private func searchPost(text: String) {
-        postSearcher.searchPost(query: text)
+        postSearcher.searchPostTitle(query: text)
             .sink { completion in
                 if case let .failure(error) = completion {
                     print(error)

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
@@ -9,16 +9,18 @@ import Combine
 import Foundation
 import MacroNetwork
 
-final class SearchViewModel: ViewModelProtocol {
+final class SearchViewModel: ViewModelProtocol, PostCollectionViewProtocol {
     
     // MARK: - Properties
+    
     private var cancellables = Set<AnyCancellable>()
     private let outputSubject = PassthroughSubject<Output, Never>()
     private let postSearcher: SearchUseCase
     private var searchType: SearchType = .post
-    private (set) var searchedPostResult: [PostFindResponse] = []
+    var posts: [PostFindResponse] = []
     
-    // MARK: - init
+    // MARK: - Init
+    
     init(postSearcher: SearchUseCase) {
         self.postSearcher = postSearcher
     }
@@ -34,9 +36,14 @@ final class SearchViewModel: ViewModelProtocol {
     
     enum Output {
         case updateSearchResult([PostFindResponse])
+        case navigateToProfileView(String)
+        case navigateToReadView(Int)
     }
     
-    // MARK: - Methods
+}
+
+// MARK: - Methods
+extension SearchViewModel {
     func transform(with input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
         input
             .sink { [weak self] input in
@@ -46,7 +53,7 @@ final class SearchViewModel: ViewModelProtocol {
                 case let .search(text):
                     switch self?.searchType {
                     case .account: self?.searchAccount(text: text)
-                    case .post: self?.searchMockPost(text: text)
+                    case .post: self?.searchPost(text: text)
                     case .none: break
                     }
                 }
@@ -70,25 +77,36 @@ final class SearchViewModel: ViewModelProtocol {
                     print(error)
                 }
             } receiveValue: { [weak self] response in
-                self?.searchedPostResult = response
+                self?.posts = response
                 let defaultValue = [PostFindResponse]()
-                self?.outputSubject.send(.updateSearchResult(self?.searchedPostResult ?? defaultValue ))
-                
+                self?.outputSubject.send(.updateSearchResult(self?.posts ?? defaultValue))
             }.store(in: &cancellables)
     }
     
+    func navigateToProfileView(userId: String) {
+        outputSubject.send(.navigateToProfileView(userId))
+    }
+    
+    func navigateToReadView(postId: Int) {
+        outputSubject.send(.navigateToReadView(postId))
+    }
+}
+
+// MARK: - Mock Methods
+
+extension SearchViewModel {
     private func searchMockPost(text: String) {
         postSearcher.searchMockPost(query: text, json: "tempJson").sink { completion in
             if case let .failure(error) = completion {
                 print(error)
             }
         } receiveValue: { [weak self] response in
-            self?.searchedPostResult = response
-            self?.searchedPostResult.removeAll { post in
+            self?.posts = response
+            self?.posts.removeAll { post in
                 !post.title.contains(text)
             }
             let defaultValue = [PostFindResponse]()
-            self?.outputSubject.send(.updateSearchResult(self?.searchedPostResult ?? defaultValue ))
+            self?.outputSubject.send(.updateSearchResult(self?.posts ?? defaultValue ))
         }.store(in: &cancellables)
     }
 }

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
@@ -83,8 +83,8 @@ extension SearchViewModel {
             }.store(in: &cancellables)
     }
     
-    func navigateToProfileView(userId: String) {
-        outputSubject.send(.navigateToProfileView(userId))
+    func navigateToProfileView(email: String) {
+        outputSubject.send(.navigateToProfileView(email))
     }
     
     func navigateToReadView(postId: Int) {

--- a/iOS/Macro/Macro/Scene/Search/Network/PostFindEndPoint.swift
+++ b/iOS/Macro/Macro/Scene/Search/Network/PostFindEndPoint.swift
@@ -19,13 +19,14 @@ extension PostFindEndPoint: EndPoint {
     }
     
     var headers: MacroNetwork.HTTPHeaders {
-        return []
+        let token = KeyChainManager.load(key: "AccessToken") ?? ""
+            return ["Authorization": "Bearer \(token)"]
     }
     
     var parameter: MacroNetwork.HTTPParameter {
         switch self {
         case let .search(text):
-            return .query(["post": text])
+            return .query(["title": text])
         }
     }
     
@@ -37,6 +38,6 @@ extension PostFindEndPoint: EndPoint {
     }
     
     var path: String {
-        return ""
+        return "post/search"
     }
 }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoHeaderView.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoHeaderView.swift
@@ -90,7 +90,7 @@ extension UserInfoHeaderView {
 // MARK: - Methods
 
 extension UserInfoHeaderView {
-    func configure(item: ProfileGetResponse) {
+    func configure(item: UserProfile) {
         self.userNameLabel.text = item.name
         userInfoProfileView.configure(item: item)
     }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoProfileView.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoProfileView.swift
@@ -100,13 +100,13 @@ extension UserInfoProfileView {
 
 // MARK: - Methods
 extension UserInfoProfileView {
-    func configure(item: ProfileGetResponse) {
+    func configure(item: UserProfile) {
         // TODO: nil 일 경우 default 이미지
         loadImage(profileImageStringURL: item.imageUrl ?? "") { image in
             self.userProfileImageView.image = image
         }
         
-        self.userFollowerCountLabel.text = "\(item.follower)"
+    //    self.userFollowerCountLabel.text = "\(item.follower)"
         self.userIntroduceLabel.text = item.introduce
         self.userFollowerCountLabel.text = "\(item.followersNum)"
     }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoProfileView.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoProfileView.swift
@@ -101,7 +101,8 @@ extension UserInfoProfileView {
 // MARK: - Methods
 extension UserInfoProfileView {
     func configure(item: ProfileGetResponse) {
-        loadImage(profileImageStringURL: item.imageUrl) { image in
+        // TODO: nil 일 경우 default 이미지
+        loadImage(profileImageStringURL: item.imageUrl ?? "") { image in
             self.userProfileImageView.image = image
         }
         

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
@@ -25,7 +25,7 @@ final class UserInfoViewController: UIViewController {
     override func viewDidLoad() {
         self.view.backgroundColor = UIColor.appColor(.blue1)
         bind()
-        inputSubject.send(.searchMockUserProfile(userId: "jinhaday@gmail.com"))
+        inputSubject.send(.searchUserProfile(email: viewModel.searchUserEmail))
         setUpLayout()
         super.viewDidLoad()
     }
@@ -34,8 +34,8 @@ final class UserInfoViewController: UIViewController {
     
     init(viewModel: UserInfoViewModel, userInfo: String) {
         self.viewModel = viewModel
+        viewModel.searchUserEmail = userInfo 
         super.init(nibName: nil, bundle: nil)
-        
     }
     
     required init?(coder: NSCoder) {

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
@@ -108,7 +108,7 @@ private extension UserInfoViewController {
         userInfoHeaderView.updateFollow(item: result)
     }
     
-    func updateUserProfile(_ result: ProfileGetResponse) {
+    func updateUserProfile(_ result: UserProfile) {
         userInfoHeaderView.configure(item: result)
     }
     

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
@@ -91,6 +91,8 @@ private extension UserInfoViewController {
                 self?.updateFollowResult(result)
             case let .updateUserProfile(result):
                 self?.updateUserProfile(result)
+            case let .updateUserPost(result):
+                self?.updateUserPost(result)
             default: break
             }
         }.store(in: &cancellables)
@@ -101,10 +103,6 @@ private extension UserInfoViewController {
 // MARK: - Methods
 
 private extension UserInfoViewController {
-    func updateSearchResult(_ result: [PostFindResponse]) {
-        homeCollectionView.viewModel.posts += result
-        homeCollectionView.reloadData()
-    }
     
     func updateFollowResult(_ result: FollowResponse) {
         userInfoHeaderView.updateFollow(item: result)
@@ -112,6 +110,10 @@ private extension UserInfoViewController {
     
     func updateUserProfile(_ result: ProfileGetResponse) {
         userInfoHeaderView.configure(item: result)
-        updateSearchResult(result.posts)
+    }
+    
+    func updateUserPost(_ result: [PostFindResponse]) {
+        homeCollectionView.viewModel.posts = result
+        homeCollectionView.reloadData()
     }
 }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
@@ -45,6 +45,7 @@ final class UserInfoViewModel: ViewModelProtocol {
         case navigateToReadView(Int)
         case updateFollowResult(FollowResponse)
         case updateUserProfile(ProfileGetResponse)
+        case updateUserPost([PostFindResponse])
     }
     
     // MARK: - Methods
@@ -68,7 +69,6 @@ final class UserInfoViewModel: ViewModelProtocol {
     private func tappedFollowButton(followUserId: String) {
         // TODO: - 통신코드 목파일 수정
         followFeature.mockFollowUser(userId: "asdf", followUserId: followUserId, json: "FollowMock").sink { _ in
-
         } receiveValue: { [weak self] response in
             self?.outputSubject.send(.updateFollowResult(response))
         }.store(in: &cancellables)
@@ -84,9 +84,9 @@ final class UserInfoViewModel: ViewModelProtocol {
         searcher.searchPost(query: searchUserEmail).sink { _ in
         } receiveValue: { [weak self] response in
             self?.posts = response
-            print(response)
+            self?.outputSubject.send(.updateUserPost(response))
         }.store(in: &cancellables)
-      
+        
     }
     
     private func searchMockUserProfile(userId: String) {

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
@@ -44,7 +44,7 @@ final class UserInfoViewModel: ViewModelProtocol {
         case navigateToProfileView(String)
         case navigateToReadView(Int)
         case updateFollowResult(FollowResponse)
-        case updateUserProfile(ProfileGetResponse)
+        case updateUserProfile(UserProfile)
         case updateUserPost([PostFindResponse])
     }
     
@@ -79,6 +79,7 @@ final class UserInfoViewModel: ViewModelProtocol {
         searcher.searchUserProfile(query: searchUserEmail).sink { _ in
         } receiveValue: { [weak self] response in
             self?.userProfile = response
+            self?.outputSubject.send(.updateUserProfile(response))
         }.store(in: &cancellables)
         
         searcher.searchPost(query: searchUserEmail).sink { _ in
@@ -92,7 +93,7 @@ final class UserInfoViewModel: ViewModelProtocol {
     private func searchMockUserProfile(userId: String) {
         searcher.searchMockUserProfile(query: userId, json: "UserInfoMock").sink { _ in
         } receiveValue: { [weak self] response in
-            self?.outputSubject.send(.updateUserProfile(response))
+           // self?.outputSubject.send(.updateUserProfile(response))
         }.store(in: &cancellables)
     }
 }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
@@ -14,6 +14,7 @@ final class UserInfoViewModel: ViewModelProtocol {
     
     var posts: [PostFindResponse] = []
     var userProfile: UserProfile = UserProfile(email: "", name: "", imageUrl: nil, introduce: nil, followersNum: 0, followeesNum: 0)
+    var searchUserEmail = ""
     private var cancellables = Set<AnyCancellable>()
     private let outputSubject = PassthroughSubject<Output, Never>()
     let searcher: SearchUseCase
@@ -29,7 +30,7 @@ final class UserInfoViewModel: ViewModelProtocol {
     // MARK: - Input
     
     enum Input {
-        case searchUserProfile(userId: String)
+        case searchUserProfile(email: String)
         case tapFollowButton(userId: String)
         
         // Mock
@@ -75,6 +76,17 @@ final class UserInfoViewModel: ViewModelProtocol {
     
     private func searchUserProfile() {
         
+        searcher.searchUserProfile(query: searchUserEmail).sink { _ in
+        } receiveValue: { [weak self] response in
+            self?.userProfile = response
+        }.store(in: &cancellables)
+        
+        searcher.searchPost(query: searchUserEmail).sink { _ in
+        } receiveValue: { [weak self] response in
+            self?.posts = response
+            print(response)
+        }.store(in: &cancellables)
+      
     }
     
     private func searchMockUserProfile(userId: String) {

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
@@ -13,6 +13,7 @@ final class UserInfoViewModel: ViewModelProtocol {
     // MARK: - Properties
     
     var posts: [PostFindResponse] = []
+    var userProfile: UserProfile = UserProfile(email: "", name: "", imageUrl: nil, introduce: nil, followersNum: 0, followeesNum: 0)
     private var cancellables = Set<AnyCancellable>()
     private let outputSubject = PassthroughSubject<Output, Never>()
     let searcher: SearchUseCase
@@ -87,8 +88,8 @@ final class UserInfoViewModel: ViewModelProtocol {
 // MARK: - PostCollectionView Delegate
 extension UserInfoViewModel: PostCollectionViewProtocol {
     
-    func navigateToProfileView(userId: String) {
-        self.outputSubject.send(.navigateToProfileView(userId))
+    func navigateToProfileView(email: String) {
+        self.outputSubject.send(.navigateToProfileView(email))
     }
     
     func navigateToReadView(postId: Int) {

--- a/iOS/Macro/Macro/Scene/UserInfo/Network/PostSearchEndPoint.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/Network/PostSearchEndPoint.swift
@@ -1,18 +1,18 @@
 //
-//  UserInfoEndPoint.swift
+//  PostSearchEndPoint.swift
 //  Macro
 //
-//  Created by Byeon jinha on 11/27/23.
+//  Created by 김나훈 on 11/29/23.
 //
 
 import Foundation
 import MacroNetwork
 
-enum UserInfoEndPoint {
+enum PostSearchEndPoint {
     case search(String)
 }
 
-extension UserInfoEndPoint: EndPoint {
+extension PostSearchEndPoint: EndPoint {
     
     var baseURL: String {
         return "https://jijihuny.store"
@@ -38,6 +38,6 @@ extension UserInfoEndPoint: EndPoint {
     }
     
     var path: String {
-        return "user/profile"
+        return "post/search"
     }
 }


### PR DESCRIPTION
## 개요 📖

구현된 API 에 대해서 Mock 대신 연결 필요

## 설명 📄

1. Search page에서 글 제목 기준으로 검색 가능
2. Home page에서 유저 셀을 누르면, 해당 유저가 작성한 게시글, 해당 유저의 실제 정보 확인 가능
3. loacationInfo page의 UI 피그마에 맞게 작업

https://github.com/boostcampwm2023/iOS03-Macro/assets/118811606/62f3829d-55a7-49bf-88b4-e4033e05e3b1






