### PR TITLE
[improve] [#180] ConfigModule 리팩토링과 타입 안정성 확보

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,19 +4,19 @@ import { AppService } from './app.service';
 import { PostModule } from './post/post.module';
 import { UserModule } from './user/user.module';
 import { MapModule } from './map/map.module';
-import { AppConfigModule } from './config/app.config.module';
 import { AuthModule } from './auth/auth.module';
 import { UtilsModule } from './utils/utils.module';
 import { FileModule } from './file/file.module';
 import { RouteModule } from './route/route.module';
 import { LoggerModule } from 'logger/logger.module';
 import { SentimentModule } from 'sentiment/sentiment.module';
+import { ConfigManagerModule } from 'config/config.manager.module';
 
 @Module({
   imports: [
     PostModule,
     UserModule,
-    AppConfigModule,
+    ConfigManagerModule,
     MapModule,
     RouteModule,
     AuthModule,

--- a/server/src/config/app.config.module.ts
+++ b/server/src/config/app.config.module.ts
@@ -1,8 +1,0 @@
-import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import appConfig from './app.config';
-
-@Module({
-  imports: [ConfigModule.forRoot({ load: [appConfig], isGlobal: true })],
-})
-export class AppConfigModule {}

--- a/server/src/config/config.manager.module.ts
+++ b/server/src/config/config.manager.module.ts
@@ -6,27 +6,32 @@ import { validateOrReject } from 'class-validator';
 import { instanceToPlain, plainToInstance } from 'class-transformer';
 
 @Module({
-  imports: [ConfigModule.forRoot({ load: [configManagerOptionsFactory], isGlobal: true })],
+  imports: [
+    ConfigModule.forRoot({
+      load: [configManagerOptionsFactory],
+      isGlobal: true,
+    }),
+  ],
 })
 export class ConfigManagerModule {
-  static registerAs<T extends Record<string, any>>({schema, path}: ConfigManagerRegisterOptions<T>): DynamicModule {
+  static registerAs<T extends Record<string, any>>({
+    schema,
+    path,
+  }: ConfigManagerRegisterOptions<T>): DynamicModule {
     return {
       module: ConfigManagerModule,
       providers: [
         {
           inject: [ConfigService],
           provide: schema,
-          useFactory: async (configService: ConfigService)=> {
+          useFactory: async (configService: ConfigService) => {
             const config = plainToInstance(schema, configService.get(path));
-            await validateOrReject(config, {whitelist: true});
+            await validateOrReject(config, { whitelist: true });
             return instanceToPlain(config);
-          }
-        }
+          },
+        },
       ],
-      exports: [
-        schema
-      ]
-    }
+      exports: [schema],
+    };
   }
 }
-

--- a/server/src/config/config.manager.module.ts
+++ b/server/src/config/config.manager.module.ts
@@ -1,0 +1,32 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import configManagerOptionsFactory from './config.manager.options.factory';
+import { ConfigManagerRegisterOptions } from './config.manager.register.options';
+import { validateOrReject } from 'class-validator';
+import { instanceToPlain, plainToInstance } from 'class-transformer';
+
+@Module({
+  imports: [ConfigModule.forRoot({ load: [configManagerOptionsFactory], isGlobal: true })],
+})
+export class ConfigManagerModule {
+  static registerAs<T extends Record<string, any>>({schema, path}: ConfigManagerRegisterOptions<T>): DynamicModule {
+    return {
+      module: ConfigManagerModule,
+      providers: [
+        {
+          inject: [ConfigService],
+          provide: schema,
+          useFactory: async (configService: ConfigService)=> {
+            const config = plainToInstance(schema, configService.get(path));
+            await validateOrReject(config, {whitelist: true});
+            return instanceToPlain(config);
+          }
+        }
+      ],
+      exports: [
+        schema
+      ]
+    }
+  }
+}
+

--- a/server/src/config/config.manager.options.factory.ts
+++ b/server/src/config/config.manager.options.factory.ts
@@ -2,9 +2,9 @@ import { readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { createSecretKey } from 'crypto';
 
-export default () => {
+export default (path?: string) => {
   const config: Record<string, any> = load(
-    readFileSync('application.yaml', 'utf-8'),
+    readFileSync(path ?? 'application.yaml', 'utf-8'),
   );
   config.application.jwt.secret = createSecretKey(
     config.application.jwt.secret,

--- a/server/src/config/config.manager.register.options.ts
+++ b/server/src/config/config.manager.register.options.ts
@@ -1,7 +1,6 @@
-import { ClassConstructor } from "class-transformer";
+import { ClassConstructor } from 'class-transformer';
 
-
-export interface ConfigManagerRegisterOptions<T extends Object> {
-    schema: ClassConstructor<T>;
-    path: string;
+export interface ConfigManagerRegisterOptions<T extends Record<string, any>> {
+  schema: ClassConstructor<T>;
+  path: string;
 }

--- a/server/src/config/config.manager.register.options.ts
+++ b/server/src/config/config.manager.register.options.ts
@@ -1,0 +1,7 @@
+import { ClassConstructor } from "class-transformer";
+
+
+export interface ConfigManagerRegisterOptions<T extends Object> {
+    schema: ClassConstructor<T>;
+    path: string;
+}

--- a/server/src/logger/logger.module.ts
+++ b/server/src/logger/logger.module.ts
@@ -4,14 +4,16 @@ import { NcpEffectiveLogSearchAnalyticsLogger } from './ncp.elsa.logger.provider
 import { ConfigService } from '@nestjs/config';
 import { NcpEffectiveLogSearchAnalyticsConfig } from './ncp.elsa.config.dto';
 import { APPLICATION_LOGGER_SYMBOL } from './app.logger.symbol';
+import { ConfigManagerModule } from 'config/config.manager.module';
 
 @Module({
+  imports: [
+    ConfigManagerModule.registerAs({
+      schema: NcpEffectiveLogSearchAnalyticsConfig,
+      path: 'naver.elsa',
+    }),
+  ],
   providers: [
-    {
-      inject: [ConfigService],
-      provide: NcpEffectiveLogSearchAnalyticsConfig,
-      useFactory: NcpEffectiveLogSearchAnalyticsConfigFactory,
-    },
     {
       provide: APPLICATION_LOGGER_SYMBOL,
       useClass:

--- a/server/src/logger/logger.module.ts
+++ b/server/src/logger/logger.module.ts
@@ -1,7 +1,5 @@
 import { ConsoleLogger, Module } from '@nestjs/common';
-import { NcpEffectiveLogSearchAnalyticsConfigFactory } from './ncp.elsa.logger.config.factory';
 import { NcpEffectiveLogSearchAnalyticsLogger } from './ncp.elsa.logger.provider';
-import { ConfigService } from '@nestjs/config';
 import { NcpEffectiveLogSearchAnalyticsConfig } from './ncp.elsa.config.dto';
 import { APPLICATION_LOGGER_SYMBOL } from './app.logger.symbol';
 import { ConfigManagerModule } from 'config/config.manager.module';

--- a/server/src/logger/ncp.elsa.logger.config.factory.ts
+++ b/server/src/logger/ncp.elsa.logger.config.factory.ts
@@ -8,7 +8,7 @@ export const NcpEffectiveLogSearchAnalyticsConfigFactory = async (
 ) => {
   const config = plainToInstance(
     NcpEffectiveLogSearchAnalyticsConfig,
-    configService.get('ncp.elsa'),
+    configService.get('naver.elsa'),
   );
   await validateOrReject(config);
   return config;

--- a/server/src/sentiment/sentiment.analysis.config.dto.ts
+++ b/server/src/sentiment/sentiment.analysis.config.dto.ts
@@ -1,0 +1,10 @@
+import { IsObject, ValidateNested } from 'class-validator';
+import { SentimentAnalysisRequest } from './sentiment.analysis.request.dto';
+import { Type } from 'class-transformer';
+
+export class SentimentAnalysisConfig {
+  @IsObject()
+  @ValidateNested()
+  @Type(() => SentimentAnalysisRequest)
+  request: SentimentAnalysisRequest;
+}

--- a/server/src/sentiment/sentiment.analysis.query.dto.ts
+++ b/server/src/sentiment/sentiment.analysis.query.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 
-export class SentimentAnalysisBody {
+export class SentimentAnalysisQuery {
   @ApiProperty({ description: '분석할 문장입니다' })
   @IsString()
   content: string;

--- a/server/src/sentiment/sentiment.analysis.request.dto.ts
+++ b/server/src/sentiment/sentiment.analysis.request.dto.ts
@@ -1,0 +1,28 @@
+import { Type } from 'class-transformer';
+import { IsObject, IsString, IsUrl, ValidateNested } from 'class-validator';
+
+class SentimentAnalysisRequestHeaders {
+  [key: string]: any;
+
+  @IsString()
+  'X-NCP-APIGW-API-KEY-ID': string;
+
+  @IsString()
+  'X-NCP-APIGW-API-KEY': string;
+
+  @IsString()
+  'Content-Type': string = 'application/json';
+}
+
+export class SentimentAnalysisRequest {
+  @IsString()
+  method: string;
+
+  @IsUrl()
+  url: string;
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => SentimentAnalysisRequestHeaders)
+  headers: SentimentAnalysisRequestHeaders;
+}

--- a/server/src/sentiment/sentiment.controller.ts
+++ b/server/src/sentiment/sentiment.controller.ts
@@ -1,15 +1,14 @@
 import { SentimentService } from './sentiment.service';
-import { Body, Post } from '@nestjs/common';
+import { Get, Query } from '@nestjs/common';
 import {
   ApiBearerAuth,
-  ApiBody,
   ApiOperation,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { RestController } from 'utils/rest.controller.decorator';
 import { SentimentAnalysisResponse } from './sentiment.analysis.response.dto';
-import { SentimentAnalysisBody } from './sentiment.analysis.body.dto';
+import { SentimentAnalysisQuery } from './sentiment.analysis.query.dto';
 
 @ApiTags('Sentiment')
 @RestController('sentiment')
@@ -21,10 +20,9 @@ export class SentimentController {
     description: 'content 입력시 문장 별 감정을 분석해줍니다.',
   })
   @ApiResponse({ type: [SentimentAnalysisResponse] })
-  @ApiBody({ type: SentimentAnalysisBody })
   @ApiBearerAuth('access-token')
-  @Post('sentiment')
-  async sentiment(@Body() { content }: SentimentAnalysisBody) {
+  @Get('sentiment')
+  async sentiment(@Query() { content }: SentimentAnalysisQuery) {
     return await this.sentimentService.SentimentAnalysis({ content });
   }
 }

--- a/server/src/sentiment/sentiment.module.ts
+++ b/server/src/sentiment/sentiment.module.ts
@@ -1,8 +1,7 @@
-import { Global, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { SentimentController } from './sentiment.controller';
 import { SentimentService } from './sentiment.service';
 
-@Global()
 @Module({
   controllers: [SentimentController],
   providers: [SentimentService],

--- a/server/src/sentiment/sentiment.module.ts
+++ b/server/src/sentiment/sentiment.module.ts
@@ -1,8 +1,16 @@
 import { Module } from '@nestjs/common';
 import { SentimentController } from './sentiment.controller';
 import { SentimentService } from './sentiment.service';
+import { ConfigManagerModule } from 'config/config.manager.module';
+import { SentimentAnalysisConfig } from './sentiment.analysis.config.dto';
 
 @Module({
+  imports: [
+    ConfigManagerModule.registerAs({
+      schema: SentimentAnalysisConfig,
+      path: 'naver.sentiment',
+    }),
+  ],
   controllers: [SentimentController],
   providers: [SentimentService],
 })

--- a/server/src/sentiment/sentiment.service.ts
+++ b/server/src/sentiment/sentiment.service.ts
@@ -5,7 +5,7 @@ import { AxiosResponse } from 'axios';
 import { map } from 'rxjs';
 import { plainToInstance } from 'class-transformer';
 import { SentimentAnalysisResponse } from './sentiment.analysis.response.dto';
-import { SentimentAnalysisBody } from './sentiment.analysis.body.dto';
+import { SentimentAnalysisQuery } from './sentiment.analysis.query.dto';
 
 @Injectable()
 export class SentimentService {
@@ -13,7 +13,7 @@ export class SentimentService {
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
   ) {}
-  async SentimentAnalysis({ content }: SentimentAnalysisBody) {
+  async SentimentAnalysis({ content }: SentimentAnalysisQuery) {
     return this.httpService
       .post(
         this.configService.get('naver.sentiment.url'),

--- a/server/src/sentiment/sentiment.service.ts
+++ b/server/src/sentiment/sentiment.service.ts
@@ -1,29 +1,24 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { AxiosResponse } from 'axios';
 import { map } from 'rxjs';
 import { plainToInstance } from 'class-transformer';
 import { SentimentAnalysisResponse } from './sentiment.analysis.response.dto';
 import { SentimentAnalysisQuery } from './sentiment.analysis.query.dto';
+import { SentimentAnalysisConfig } from './sentiment.analysis.config.dto';
 
 @Injectable()
 export class SentimentService {
   constructor(
     private readonly httpService: HttpService,
-    private readonly configService: ConfigService,
+    private readonly sentimentAnalysisConfig: SentimentAnalysisConfig,
   ) {}
-  async SentimentAnalysis({ content }: SentimentAnalysisQuery) {
+  async SentimentAnalysis(query: SentimentAnalysisQuery) {
     return this.httpService
-      .post(
-        this.configService.get('naver.sentiment.url'),
-        {
-          content: `${content}`,
-        },
-        {
-          headers: this.configService.get('naver.sentiment.headers'),
-        },
-      )
+      .request({
+        ...this.sentimentAnalysisConfig.request,
+        data: query,
+      })
       .pipe(
         map(({ data }: AxiosResponse) => {
           return plainToInstance(SentimentAnalysisResponse, data as any[]);

--- a/server/src/user/user.followees.query.dto.ts
+++ b/server/src/user/user.followees.query.dto.ts
@@ -1,4 +1,3 @@
-import { UserProfileQuery } from "./user.profile.query.dto";
-
+import { UserProfileQuery } from './user.profile.query.dto';
 
 export class UserFolloweesQuery extends UserProfileQuery {}

--- a/server/src/user/user.followees.response.dto.ts
+++ b/server/src/user/user.followees.response.dto.ts
@@ -1,4 +1,3 @@
-import { UserProfileResponse } from "./user.profile.response.dto";
-
+import { UserProfileResponse } from './user.profile.response.dto';
 
 export class UserFolloweesResponse extends UserProfileResponse {}

--- a/server/src/user/user.followers.query.dto.ts
+++ b/server/src/user/user.followers.query.dto.ts
@@ -1,4 +1,3 @@
-import { UserProfileQuery } from "./user.profile.query.dto";
-
+import { UserProfileQuery } from './user.profile.query.dto';
 
 export class UserFollowersQuery extends UserProfileQuery {}

--- a/server/src/user/user.followers.response.dto.ts
+++ b/server/src/user/user.followers.response.dto.ts
@@ -1,4 +1,3 @@
-import { UserProfileResponse } from "./user.profile.response.dto";
-
+import { UserProfileResponse } from './user.profile.response.dto';
 
 export class UserFollowersResponse extends UserProfileResponse {}


### PR DESCRIPTION
## 개요 📖

- #180 
- ConfigModule을 리팩토링하여 모듈 간 설정 파일에 대한 관심사를 분리하고 타입안정성을 확보합니다.
 
## 설명 📄

기존엔 설정 파일에 대한 의존성이 모두에게 동일하여
```ts

@Injectable()
export class SomeService {
  constructor(
    configService: ConfigService
  ) {}

  async doSomething() {
    ...
    this.configService.get('some.config.options')
    ...
  }
```
와 같이 ConfigService를 주입받아야만 했습니다.

이는 타입스크립트의 타입 안정성을 유지하지 못하고,
또 적절한 Config경로를 매번 작성해주어야만 하는 상황입니다.


이제
```ts
export class SomeConfig {
...
}

@Module({
  imports: [ ConfigManagerModule.registerAs({ schema: SomeConfig, path: 'path' })]
})
export class SomeModule {}


@Injectable()
export class SomeService {
  constructor(someConfig: SomeConfig) {}
}
```

와 같이 각 모듈마다 Config에 대한 스키마로 관심사를 좁히고 타입 안정성을 확보할 수 있게 되었습니다.

## Close Issue

Close #180