### PR TITLE
[feat][#196] post refresh, post load 구현

### DIFF
--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
@@ -8,7 +8,7 @@
 import Combine
 import UIKit
 
-final class PostCollectionView: UICollectionView, UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+final class PostCollectionView: UICollectionView {
     
     // MARK: - Properties
     
@@ -16,6 +16,7 @@ final class PostCollectionView: UICollectionView, UICollectionViewDelegate, UICo
     private var cancellables = Set<AnyCancellable>()
     weak var postDelegate: PostCollectionViewDelegate?
     private let inputSubject: PassthroughSubject<PostCollectionViewModel.Input, Never> = .init()
+    private let postRefreshControl: UIRefreshControl = UIRefreshControl()
     
     // MARK: - Initialization
     
@@ -29,9 +30,9 @@ final class PostCollectionView: UICollectionView, UICollectionViewDelegate, UICo
         self.register(PostCollectionViewCell.self, forCellWithReuseIdentifier: "PostCollectionViewCell")
         
         self.showsVerticalScrollIndicator = false
-        
         self.delegate = self
         self.dataSource = self
+        initRefreshControl()
     }
     
     required init?(coder: NSCoder) {
@@ -39,21 +40,52 @@ final class PostCollectionView: UICollectionView, UICollectionViewDelegate, UICo
     }
     
     // MARK: - Methods
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.posts.count
+    @objc func refreshTable(refresh: UIRefreshControl) {
+        print("refreshTable")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.reloadData()
+            refresh.endRefreshing()
+        }
     }
     
+    func initRefreshControl() {
+        postRefreshControl.addTarget(self, action: #selector(refreshTable(refresh:)), for: .valueChanged)
+        postRefreshControl.backgroundColor = UIColor.clear
+        self.refreshControl = postRefreshControl
+    }
+    
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        if velocity.y < -0.1 {
+            self.refreshTable(refresh: self.postRefreshControl)
+        }
+    }
+}
+
+// MARK: - UICollectionViewDataSource Delegate
+
+extension PostCollectionView: UICollectionViewDataSource {
+    
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "PostCollectionViewCell",
-                                                            for: indexPath) as? PostCollectionViewCell
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: "PostCollectionViewCell",
+            for: indexPath) as? PostCollectionViewCell
         else { return UICollectionViewCell() }
+        
         cell.delegate = postDelegate
         let item = viewModel.posts[indexPath.row]
         cell.configure(item: item, viewModel: viewModel, indexPath: indexPath)
         return cell
     }
     
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return viewModel.posts.count
+    }
+    
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout Delegate
+
+extension PostCollectionView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -71,5 +103,4 @@ final class PostCollectionView: UICollectionView, UICollectionViewDelegate, UICo
                         insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 0, left: 0, bottom: 80, right: 0)
     }
-    
 }

--- a/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
+++ b/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
@@ -20,7 +20,7 @@ protocol SearchUseCase {
     func searchMockPost(query: String, json: String) -> AnyPublisher<[PostFindResponse], NetworkError>
     
     /// 가장 인기있는 게시물들을 받아오는 작업
-    func fetchHitPost() -> AnyPublisher<[PostFindResponse], NetworkError>
+    func fetchHitPost(postCount: Int) -> AnyPublisher<[PostFindResponse], NetworkError>
     
     /// 홈 화면의 게시글들을 해당 json 파일에서 모두 불러오는 작업
     func searchMockPost(json: String) -> AnyPublisher<[PostFindResponse], NetworkError>
@@ -70,12 +70,12 @@ final class Searcher: SearchUseCase {
         return provider.mockRequest(PostFindEndPoint.searchPost(query), url: json)
     }
     
-    func fetchHitPost() -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
-        return provider.request(PostEndPoint.search)
+    func fetchHitPost(postCount: Int) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
+        return provider.request(PostEndPoint.search(postCount))
     }
     
     func searchMockPost(json: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
-        return provider.mockRequest(PostEndPoint.search, url: json)
+        return provider.mockRequest(PostEndPoint.search(0), url: json)
     }
     
     func searchUserProfile(query: String) -> AnyPublisher<UserProfile, MacroNetwork.NetworkError> {

--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
@@ -46,7 +46,7 @@ final class HomeViewController: TouchableViewController {
         self.view.backgroundColor = UIColor.appColor(.blue1)
         bind()
         postCollectionView.postDelegate = self
-        inputSubject.send(.searchPosts)
+        inputSubject.send(.searchPosts(0))
         setUpLayout()
     }
     

--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/ViewModel/HomeViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/ViewModel/HomeViewModel.swift
@@ -13,7 +13,7 @@ final class HomeViewModel: ViewModelProtocol {
     // MARK: - Input
     
     enum Input {
-        case searchPosts
+        case searchPosts(Int)
         case searchMockPost
     }
     
@@ -52,8 +52,8 @@ extension HomeViewModel {
     func transform(with input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
         input.sink { [weak self] input in
             switch input {
-            case .searchPosts:
-              self?.searchPosts()
+            case let .searchPosts(postCount):
+                self?.searchPosts(postCount: postCount)
             case .searchMockPost:
                 self?.searchMockPost()
             }
@@ -62,8 +62,8 @@ extension HomeViewModel {
         return outputSubject.eraseToAnyPublisher()
     }
     
-    private func searchPosts() {
-        postSearcher.fetchHitPost().sink { completion in
+    private func searchPosts(postCount: Int) {
+        postSearcher.fetchHitPost(postCount: postCount).sink { completion in
             if case let .failure(error) = completion {
                 Log.make().error("\(error)")
             }

--- a/iOS/Macro/Macro/Scene/Home/Network/PostEndPoint.swift
+++ b/iOS/Macro/Macro/Scene/Home/Network/PostEndPoint.swift
@@ -9,7 +9,7 @@ import Foundation
 import MacroNetwork
 
 enum PostEndPoint {
-    case search
+    case search(Int)
 }
 
 extension PostEndPoint: EndPoint {
@@ -26,8 +26,8 @@ extension PostEndPoint: EndPoint {
     
     var parameter: MacroNetwork.HTTPParameter {
         switch self {
-        case .search:
-            return .plain
+        case let .search(postCount):
+            return .query(["sortBy": "latest", "skip": "\(postCount)"])
         }
     }
     


### PR DESCRIPTION
## 개요 📖

- 이슈번호 #196
- 게시물을 추가적으로 불러오는 로직과 재호출하는 기능을 구현합니다.

## 설명 📄

- 게시물을 추가적으로 불러오는 로직과 재호출하는 기능을 구현합니다.

## 고민거리 🤔 (Optional) - 의견 받고싶은 부분 있으면 적어두기

### Q. 고민1
코어데이터 엔터티를 수정하고, 게시물을 쓰는 기능을 제대로 다시 구현하지 않아서 게시물 수가 적습니다. 이 부분만 구현하면 실 테스트가 가능할 것 같습니다.


## Close Issues 
Close #196 