### PR TITLE
[fix][#165] Image 없으면 글 작성 안되는 문제 해결

### DIFF
--- a/iOS/Macro/Macro/Infrastructure/PersistentStorages/ImageSaveManager.swift
+++ b/iOS/Macro/Macro/Infrastructure/PersistentStorages/ImageSaveManager.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 import MacroNetwork
 
-class ImageSaveManager {
+final class ImageSaveManager {
     private var cancellables = Set<AnyCancellable>()
     
     func convertImageDataToImageURL(imageDatas: [Data], completion: @escaping (([String]) -> Void)) {

--- a/iOS/Macro/Macro/Infrastructure/PersistentStorages/ImageSaveManager.swift
+++ b/iOS/Macro/Macro/Infrastructure/PersistentStorages/ImageSaveManager.swift
@@ -9,8 +9,15 @@ import Combine
 import Foundation
 import MacroNetwork
 
-struct ImageSaveManager {
-    static func convertImageDataToImageURL(imageDatas: [Data], cancellables: inout Set<AnyCancellable>, completion: @escaping (([String]) -> Void)) {
+class ImageSaveManager {
+    private var cancellables = Set<AnyCancellable>()
+    
+    func convertImageDataToImageURL(imageDatas: [Data], completion: @escaping (([String]) -> Void)) {
+        guard !imageDatas.isEmpty else {
+            completion([])
+            return
+        }
+        
         let provider = APIProvider(session: URLSession.shared)
         let uploadImageUseCase = UploadImage(provider: provider)
         var imageURLs = [String]()
@@ -20,16 +27,13 @@ struct ImageSaveManager {
                 .sink { result in
                     if case let .failure(error) = result {
                         debugPrint("Image Upload Fail : ", error)
-                        print(12123)
                     } else if imageURLs.count == imageDatas.count {
                         completion(imageURLs)
-                        print(12145)
                     }
                 } receiveValue: { imageURLResponse in
                     imageURLs.append(imageURLResponse.url)
-                    print(imageURLResponse)
                 }
-                .store(in: &cancellables)
+                .store(in: &self.cancellables)
         }
     }
 }

--- a/iOS/Macro/Macro/Scene/Write/InterfaceAdapters/ViewModel/WriteViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Write/InterfaceAdapters/ViewModel/WriteViewModel.swift
@@ -113,7 +113,7 @@ extension WriteViewModel {
     }
     
     private func writeSubmit() {
-        ImageSaveManager.convertImageDataToImageURL(imageDatas: imageDatas, cancellables: &cancellables) { imageURLs in
+        ImageSaveManager().convertImageDataToImageURL(imageDatas: imageDatas) { imageURLs in
             imageURLs.enumerated().forEach {
                 self.contents[$0].imageURL = $1
             }


### PR DESCRIPTION
## 개요 📖

<!-- 

- #165 이미지 없으면 글 작성 안되던 문제 해결

## 설명 📄

기존에 ImageSaveManager의 convertImageDataToImageURL 메소드에서 url 배열을 반복문으로 이미지를 보내고 response를 받은 후 completion을 호출 했습니다. 하지만 배열이 비어있으면 반복문이 호출 되지 않으면서 completion이 호출되지 않는 문제가 발생했습니다.

이를 해결하기 위해 guard문을 만들어서 넣었지만 store하는 과정에서 Race Condition 문제가 생겨서 cancellables를 입력받는 것이 아닌 직접 만들어서 넣어주는 식으로 수정했습니다.

## Close Issues 🔒 (닫을 Issue)

#165 

