### PR TITLE
[fix][#230] Image Upload 및 Read 순차적으로 될 수 있도록 수정

### DIFF
--- a/iOS/Macro/Macro/Scene/Read/InterfaceAdapters/View/ReadViewController.swift
+++ b/iOS/Macro/Macro/Scene/Read/InterfaceAdapters/View/ReadViewController.swift
@@ -286,20 +286,20 @@ private extension ReadViewController {
         updateMark(recordedPindedInfo: readPost.pins)
     }
     
-    func downloadImages(imageURLs: [String], completion: @escaping ([UIImage]) -> Void) {
+    func downloadImages(imageURLs: [String], completion: @escaping ([UIImage?]) -> Void) {
         let dispatchGroup = DispatchGroup()
-        var images = [UIImage]()
+        var images: [UIImage?] = Array(repeating: nil, count: imageURLs.count)
         
-        imageURLs.forEach {
+        imageURLs.enumerated().forEach { index, imageURL in
             dispatchGroup.enter()
             
-            if let url = URL(string: $0) {
+            if let url = URL(string: imageURL) {
                 URLSession.shared.dataTask(with: url) { (data, _, _) in
                     defer {
                         dispatchGroup.leave()
                     }
                     if let data = data, let image = UIImage(data: data) {
-                        images.append(image)
+                        images[index] = image
                     } else {
                         debugPrint("Failed to download image form \(url)")
                     }

--- a/iOS/Macro/Macro/Scene/Write/InterfaceAdapters/ViewModel/WriteViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Write/InterfaceAdapters/ViewModel/WriteViewModel.swift
@@ -182,18 +182,21 @@ extension WriteViewModel {
         
         let provider = APIProvider(session: URLSession.shared)
         let uploadImageUseCase = UploadImage(provider: provider)
-        var imageURLs = [String]()
-        imageDatas.forEach { imageData in
+        var imageURLs = Array(repeating: "", count: imageDatas.count)
+        var count = 0
+        
+        imageDatas.enumerated().forEach { index, imageData in
             uploadImageUseCase.execute(imageData: imageData)
                 .receive(on: DispatchQueue.global())
                 .sink { result in
                     if case let .failure(error) = result {
                         debugPrint("Image Upload Fail : ", error)
-                    } else if imageURLs.count == imageDatas.count {
+                    } else if count == imageDatas.count {
                         completion(imageURLs)
                     }
                 } receiveValue: { imageURLResponse in
-                    imageURLs.append(imageURLResponse.url)
+                    count += 1
+                    imageURLs[index] = imageURLResponse.url
                 }
                 .store(in: &self.cancellables)
         }


### PR DESCRIPTION
## 개요 📖

- #230 이미지 업로드 및 Read가 순차적으로 될 수 있도록 수정

## 설명 📄

원인 분석

기존의 글 작성 로직은 아래와 같았다.

Submit 버튼 클릭
Image Data 타입으로 변환
각 이미지를 Object Storage에 전송 후 URL 받는 순서대로 저장
Image URL 배열 순서대로 Content로 변환 후 Post 전송
위 과정 중 3번에서 문제가 발생을 했다.
비동기적으로 Data를 보내고 받은 데이터 부터 배열에 추가해주기 때문에
Data를 보내는 순서대로 처리가 되는 것이 아니라 받는 순서대로 데이터가 쌓여있다.
이를 데이터를 보내는 순서와 맞게 데이터를 받는 방법을 고민해야 한다.

문제 해결 과정

index를 부여했습니다.

기존에는 빈 배열을 만들고 거기에 append 시켜주고 그것이 Image Data 배열과 크기가 같을 때 반환하는 방식으로 진행을 했습니다.
방식을 조금 바꿔서 Data 양만큼의 빈 값을 가진 배열을 만들고 거기에 넣어주는 방식을 채택했습니다.

## 고민거리 🤔

지금은 배열 크기를 새로 만들어서 인덱스에 넣는 방식으로 하는데 이것이 자연스럽지 못하다는 느낌을 받았습니다.
좀 더 나은 개선 방법이 있다면 의견 주시면 좋을 것 같습니다.

## 스크린샷 📷

| Before | After |
| -------- | -------- |
|  ![image](https://github.com/boostcampwm2023/iOS03-Macro/assets/37203016/f5dc3166-9ede-49fc-8289-24045ccfa504) | ![image](https://github.com/boostcampwm2023/iOS03-Macro/assets/37203016/22f31f81-6551-495c-a0b5-88372eeee259) |

## Close Issues 🔒 (닫을 Issue)

Close #230 
