### PR TITLE
[feat][#213] 컬렉션뷰 버그 픽스

### DIFF
--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		D2CAA5E72B1F14BE00E825BA /* FollowListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CAA5E62B1F14BE00E825BA /* FollowListEndPoint.swift */; };
 		D2CAA5E92B1F23AA00E825BA /* FollowResultCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CAA5E82B1F23AA00E825BA /* FollowResultCollectionView.swift */; };
 		D2CAA5EB2B1F23B700E825BA /* FollowResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CAA5EA2B1F23B700E825BA /* FollowResultCell.swift */; };
+		D2CAA5EF2B208F5D00E825BA /* SceneType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CAA5EE2B208F5D00E825BA /* SceneType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -338,6 +339,7 @@
 		D2CAA5E62B1F14BE00E825BA /* FollowListEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowListEndPoint.swift; sourceTree = "<group>"; };
 		D2CAA5E82B1F23AA00E825BA /* FollowResultCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowResultCollectionView.swift; sourceTree = "<group>"; };
 		D2CAA5EA2B1F23B700E825BA /* FollowResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowResultCell.swift; sourceTree = "<group>"; };
+		D2CAA5EE2B208F5D00E825BA /* SceneType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneType.swift; sourceTree = "<group>"; };
 		EFE56344E8979EDA80D9E782 /* libPods-Macro.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Macro.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE963544592A2BC35C2CD604 /* Pods-Macro.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Macro.release.xcconfig"; path = "Target Support Files/Pods-Macro/Pods-Macro.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1218,6 +1220,7 @@
 				AAD0B31B2B171171003B4D5F /* Cotent.swift */,
 				AAD0B31D2B171187003B4D5F /* Coordinate.swift */,
 				BAE3C5852B1995D200BF9798 /* LikePostResponse.swift */,
+				D2CAA5EE2B208F5D00E825BA /* SceneType.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";

--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		D2CAA5E92B1F23AA00E825BA /* FollowResultCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CAA5E82B1F23AA00E825BA /* FollowResultCollectionView.swift */; };
 		D2CAA5EB2B1F23B700E825BA /* FollowResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CAA5EA2B1F23B700E825BA /* FollowResultCell.swift */; };
 		D2CAA5EF2B208F5D00E825BA /* SceneType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CAA5EE2B208F5D00E825BA /* SceneType.swift */; };
+		D2EDFAAE2B212B9B00723E7E /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EDFAAD2B212B9B00723E7E /* UIView+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -340,6 +341,7 @@
 		D2CAA5E82B1F23AA00E825BA /* FollowResultCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowResultCollectionView.swift; sourceTree = "<group>"; };
 		D2CAA5EA2B1F23B700E825BA /* FollowResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowResultCell.swift; sourceTree = "<group>"; };
 		D2CAA5EE2B208F5D00E825BA /* SceneType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneType.swift; sourceTree = "<group>"; };
+		D2EDFAAD2B212B9B00723E7E /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		EFE56344E8979EDA80D9E782 /* libPods-Macro.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Macro.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE963544592A2BC35C2CD604 /* Pods-Macro.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Macro.release.xcconfig"; path = "Target Support Files/Pods-Macro/Pods-Macro.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -787,6 +789,7 @@
 				BA90CB3A2B0EF88700365AE2 /* LocationManager.swift */,
 				D21B10482B19854900F2F84E /* UIViewController+.swift */,
 				D21B104A2B1A22D500F2F84E /* Log.swift */,
+				D2EDFAAD2B212B9B00723E7E /* UIView+.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1528,6 +1531,7 @@
 				AAD0B3252B17477A003B4D5F /* PostUploadEndPoint.swift in Sources */,
 				D21B10102B16FDA000F2F84E /* PostSearchEndPoint.swift in Sources */,
 				BA90CB9E2B145CDE00365AE2 /* FollowEndPoint.swift in Sources */,
+				D2EDFAAE2B212B9B00723E7E /* UIView+.swift in Sources */,
 				BA6C6DF42B05FFC500563B22 /* CircularViewProtocol.swift in Sources */,
 				D2CAA5C72B1D7E3700E825BA /* LocationInfoViewModel.swift in Sources */,
 				BA90CB982B1450A200365AE2 /* UserInfoProfileView.swift in Sources */,

--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -1518,6 +1518,7 @@
 				BA8DC3FA2B0B5DD100929E01 /* BaseViewControllerProtocol.swift in Sources */,
 				AAD0B3142B14E394003B4D5F /* ReadViewController.swift in Sources */,
 				AAD0B2DB2B0FB5A5003B4D5F /* ImageUploadEndPoint.swift in Sources */,
+				D2CAA5EF2B208F5D00E825BA /* SceneType.swift in Sources */,
 				BA33AA8C2B0AF9F30065D1E0 /* HomeHeaderView.swift in Sources */,
 				BA32E1762B0DC2F900EA0EE2 /* UserInfoViewModel.swift in Sources */,
 				BA8DC4132B0B602000929E01 /* WriteViewModel.swift in Sources */,

--- a/iOS/Macro/Macro/App/AppDelegate.swift
+++ b/iOS/Macro/Macro/App/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreData
+import CoreLocation
 import UIKit
 
 @main
@@ -16,6 +17,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let locationManager = CLLocationManager()
+        locationManager.requestWhenInUseAuthorization()
+
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
     

--- a/iOS/Macro/Macro/App/SceneDelegate.swift
+++ b/iOS/Macro/Macro/App/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import AuthenticationServices
 import Combine
+import CoreLocation
 import Network
 import MacroNetwork
 import UIKit
@@ -15,8 +16,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
     var navigationController: UINavigationController?
-    
-    
     private let queue = DispatchQueue(label: Label.queueLabel)
     private let monitor = NWPathMonitor()
     private let networkStatusSubject = PassthroughSubject<Bool, Never>()

--- a/iOS/Macro/Macro/Common/Entities/SceneType.swift
+++ b/iOS/Macro/Macro/Common/Entities/SceneType.swift
@@ -1,0 +1,15 @@
+//
+//  SceneType.swift
+//  Macro
+//
+//  Created by 김나훈 on 12/6/23.
+//
+
+import Foundation
+
+enum SceneType {
+    case home
+    case searchPostTitle
+    case userInfoPost
+    case relatedPost
+}

--- a/iOS/Macro/Macro/Common/Entities/UserProfile.swift
+++ b/iOS/Macro/Macro/Common/Entities/UserProfile.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct UserProfile: Codable {
     let email: String
-    let name: String
-    let imageUrl: String?
-    let introduce: String?
+    var name: String
+    var imageUrl: String?
+    var introduce: String?
     let followersNum: Int
     let followeesNum: Int
     let followee: Bool

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
@@ -70,13 +70,7 @@ extension PostCollectionViewCell {
             
         ])
     }
-    
-    func componetConfigure(item: PostFindResponse) {
-        postContentView.setLayout()
-        postContentView.configure(item: item, viewModel: self.viewModel)
-        postProfileView.setLayout()
-        postProfileView.configure(item: item, viewModel: self.viewModel)
-    }
+
 }
 
 // MARK: - Methods
@@ -87,15 +81,14 @@ extension PostCollectionViewCell {
         self.viewModel = viewModel
         postContentView.configure(item: item, viewModel: viewModel)
         postProfileView.configure(item: item, viewModel: viewModel)
+        postContentView.setLayout()
+        postProfileView.setLayout()
         postProfileView.indexPath = indexPath
         postContentView.delegate = delegate
         postProfileView.delegate = delegate
-        postProfileView.bind()
-        postContentView.bind()
         setTranslatesAutoresizingMaskIntoConstraints()
         addsubviews()
         setLayoutConstraints()
-        componetConfigure(item: item)
     }
     
 }

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewModel.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewModel.swift
@@ -21,6 +21,7 @@ final class PostCollectionViewModel: ViewModelProtocol {
     let patcher: PatchUseCase
     let postSearcher: SearchUseCase
     var isLastPost: Bool = false
+    private let sceneType: SceneType
     
     enum Input {
         case navigateToReadView(Int)
@@ -38,11 +39,11 @@ final class PostCollectionViewModel: ViewModelProtocol {
         case updatePostContnet
     }
     
-    init(posts: [PostFindResponse], followFeature: FollowUseCase, patcher: PatchUseCase, postSearcher: SearchUseCase) {
-        self.posts = posts
+    init(followFeature: FollowUseCase, patcher: PatchUseCase, postSearcher: SearchUseCase, sceneType: SceneType) {
         self.followFeatrue = followFeature
         self.patcher = patcher
         self.postSearcher = postSearcher
+        self.sceneType = sceneType
     }
     
 }

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewModel.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewModel.swift
@@ -8,8 +8,6 @@
 import Combine
 import Foundation
 import MacroNetwork
-
-// TODO: ViewModel에서 UIKit 지우기. 현재 loadImage 부분 때문에 import 중입니다.
 import UIKit
 
 final class PostCollectionViewModel: ViewModelProtocol {
@@ -22,6 +20,7 @@ final class PostCollectionViewModel: ViewModelProtocol {
     let postSearcher: SearchUseCase
     var isLastPost: Bool = false
     private let sceneType: SceneType
+    var query: String?
     
     enum Input {
         case navigateToReadView(Int)
@@ -72,9 +71,21 @@ extension PostCollectionViewModel {
             outputSubject.send(.updatePostView(postId, posts[index].viewNum))
         }
     }
-
+    
     func getNextPost(_ pageNum: Int) {
-        postSearcher.fetchHitPost(postCount: posts.count).sink { completion in
+        let publisher: AnyPublisher<[PostFindResponse], NetworkError>
+        
+        switch sceneType {
+        case .home: 
+            publisher = postSearcher.fetchHitPost(postCount: posts.count)
+        case .relatedPost: 
+            publisher = postSearcher.searchRelatedPost(query: query ?? "", postCount: posts.count)
+        case .searchPostTitle:
+            publisher = postSearcher.searchPostTitle(query: query ?? "", postCount: posts.count)
+        case .userInfoPost:
+            publisher = postSearcher.searchPost(query: query ?? "", postCount: posts.count)
+        }
+        publisher.sink { completion in
             if case let .failure(error) = completion {
                 Log.make().error("\(error)")
             }

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostContentView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostContentView.swift
@@ -77,13 +77,6 @@ final class PostContentView: UIView {
     
 }
 
-extension PostContentView {
-    func bind() {
-        guard let viewModel = self.viewModel else { return }
-        _ = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
-        
-    }
-}
 // MARK: - UI Settings
 
 private extension PostContentView {
@@ -131,12 +124,6 @@ private extension PostContentView {
     }
     
 }
-
-// MARK: - Bind
-
-extension PostContentView {
-    
-}
 // MARK: - Methods
 
 extension PostContentView {
@@ -151,25 +138,41 @@ extension PostContentView {
     func configure(item: PostFindResponse, viewModel: PostCollectionViewModel?) {
         self.viewModel = viewModel
         guard let viewModel = self.viewModel else { return }
-        self.imageUrl = item.imageUrl ?? "default_url"
-        guard let imageUrl = self.imageUrl else { return }
-        viewModel.loadImage(profileImageStringURL: imageUrl) { [weak self] image in
-            guard let self = self else { return }
-            DispatchQueue.main.async {
-                if self.imageUrl == item.imageUrl {
-                    self.mainImageView.image = image
-                }
-                else {
-                    let defaultImage = UIImage.appImage(.ProfileDefaultImage)
-                    self.mainImageView.image = defaultImage
+        
+        if let imageUrl = item.imageUrl, isValidUrl(urlString: imageUrl) {
+            viewModel.loadImage(profileImageStringURL: imageUrl) { [weak self] image in
+                DispatchQueue.main.async {
+                    if let image = image {
+                        self?.setProfileImage(image)
+                    } else {
+                        self?.setDefaultProfileImage()
+                    }
                 }
             }
+        } else {
+            setDefaultProfileImage()
         }
         
         title.text = item.title
         summary.text = item.summary
         postId = item.postId
     }
+    private func setDefaultProfileImage() {
+        let defaultImage = UIImage.appImage(.ProfileDefaultImage)
+        setProfileImage(defaultImage)
+    }
+    
+    private func setProfileImage(_ image: UIImage?) {
+        mainImageView.image = image
+    }
+    
+    private func isValidUrl(urlString: String) -> Bool {
+        if let url = URL(string: urlString) {
+            return UIApplication.shared.canOpenURL(url)
+        }
+        return false
+    }
+    
     func resetContents() {
         mainImageView.image = nil
         title.text = ""

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostContentView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostContentView.swift
@@ -166,13 +166,6 @@ extension PostContentView {
         mainImageView.image = image
     }
     
-    private func isValidUrl(urlString: String) -> Bool {
-        if let url = URL(string: urlString) {
-            return UIApplication.shared.canOpenURL(url)
-        }
-        return false
-    }
-    
     func resetContents() {
         mainImageView.image = nil
         title.text = ""

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
@@ -93,12 +93,6 @@ final class PostProfileView: UIView {
         delegate?.didTapProfile(viewController: userInfoViewController)
     }
     
-    @objc private func likeImageViewTap(_ sender: UITapGestureRecognizer) {
-        guard let _ = viewModel else { return }
-        guard let postId: Int = self.postId else { return }
-        inputSubject.send(.touchLike(postId))
-    }
-    
 }
 
 // MARK: - UI Settings
@@ -164,30 +158,8 @@ extension PostProfileView {
         profileImageView.isUserInteractionEnabled = true
         let profileImageViewTapGesture = UITapGestureRecognizer(target: self, action: #selector(profileImageTap(_:)))
         profileImageView.addGestureRecognizer(profileImageViewTapGesture)
-        
-        likeImageView.isUserInteractionEnabled = true
-        let likeImageViewTapGesture = UITapGestureRecognizer(target: self, action: #selector(likeImageViewTap(_:)))
-        likeImageView.addGestureRecognizer(likeImageViewTapGesture)
     }
     
-}
-
-extension PostProfileView {
-    func bind() {
-        guard let viewModel = self.viewModel, let postId = self.postId else { return }
-        
-        let outputSubject = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
-        
-        outputSubject.receive(on: RunLoop.main).sink { [weak self] output in
-            switch output {
-            case .updatePostLike(let likePostResponse) where likePostResponse.postId == postId:
-                self?.likeCountLabel.text = "\(likePostResponse.likeNum)"
-            case .updatePostView(let updatedPostId, let updatedViewNum) where updatedPostId == postId:
-                self?.viewCountLabel.text = "\(updatedViewNum)"
-            default: break
-            }
-        }.store(in: &cancellables)
-    }
 }
 
 // MARK: - Method
@@ -196,26 +168,42 @@ extension PostProfileView {
     func configure(item: PostFindResponse, viewModel: PostCollectionViewModel?) {
         self.viewModel = viewModel
         guard let viewModel = self.viewModel else { return }
-        self.imageUrl = item.writer.imageUrl ?? "default_url"
-        guard let imageUrl = self.imageUrl else { return }
-        viewModel.loadImage(profileImageStringURL: imageUrl) { [weak self] image in
-            guard let self = self else { return }
-            DispatchQueue.main.async {
-                if self.imageUrl == item.writer.imageUrl {
-                    self.profileImageView.image = image
+
+        if let imageUrl = item.writer.imageUrl, isValidUrl(urlString: imageUrl) {
+            viewModel.loadImage(profileImageStringURL: imageUrl) { [weak self] image in
+                DispatchQueue.main.async {
+                    if let image = image {
+                        self?.setProfileImage(image)
+                    } else {
+                        self?.setDefaultProfileImage()
+                    }
                 }
-                else {
-                    let defaultImage = UIImage.appImage(.ProfileDefaultImage)
-                    self.profileImageView.image = defaultImage
-                }
-                self.profileImageView.layer.cornerRadius = self.profileImageView.frame.width / 2
             }
+        } else {
+            setDefaultProfileImage()
         }
+
         userNameLabel.text = item.writer.name
         likeCountLabel.text = "\(item.likeNum)"
         viewCountLabel.text = "\(item.viewNum)"
         postId = item.postId
     }
+    private func setDefaultProfileImage() {
+        let defaultImage = UIImage.appImage(.ProfileDefaultImage)
+        setProfileImage(defaultImage)
+    }
+
+    private func setProfileImage(_ image: UIImage?) {
+        profileImageView.image = image
+        profileImageView.layer.cornerRadius = profileImageView.frame.width / 2
+    }
+    private func isValidUrl(urlString: String) -> Bool {
+        if let url = URL(string: urlString) {
+            return UIApplication.shared.canOpenURL(url)
+        }
+        return false
+    }
+    
     func resetContents() {
         profileImageView.image = nil
         userNameLabel.text = ""

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
@@ -197,12 +197,6 @@ extension PostProfileView {
         profileImageView.image = image
         profileImageView.layer.cornerRadius = profileImageView.frame.width / 2
     }
-    private func isValidUrl(urlString: String) -> Bool {
-        if let url = URL(string: urlString) {
-            return UIApplication.shared.canOpenURL(url)
-        }
-        return false
-    }
     
     func resetContents() {
         profileImageView.image = nil

--- a/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
+++ b/iOS/Macro/Macro/Common/UseCases/SearchUseCase.swift
@@ -14,7 +14,7 @@ protocol SearchUseCase {
     func searchLocation(query: String, page: Int) -> AnyPublisher<[LocationDetail], NetworkError>
     
     /// 특정 사용자의 게시글들을 전부 불러오는 함수
-    func searchPost(query: String) -> AnyPublisher<[PostFindResponse], NetworkError>
+    func searchPost(query: String, postCount: Int) -> AnyPublisher<[PostFindResponse], NetworkError>
     
     /// 특정 검색어가 해당 json 파일 list의 제목에 포함되는지 검색
     func searchMockPost(query: String, json: String) -> AnyPublisher<[PostFindResponse], NetworkError>
@@ -32,13 +32,13 @@ protocol SearchUseCase {
     func searchMockUserProfile(query: String, json: String) -> AnyPublisher<ProfileGetResponse, NetworkError>
 
     /// 특정 제목으로 게시글을 검색
-    func searchPostTitle(query: String) -> AnyPublisher<[PostFindResponse], NetworkError>
+    func searchPostTitle(query: String, postCount: Int) -> AnyPublisher<[PostFindResponse], NetworkError>
     
     /// 특정 단어로 유저이름을 검색
     func searchAccountWord(query: String) -> AnyPublisher<[UserProfile], NetworkError>
     
     /// postId를 기준으로, 해당 장소를 다녀간 게시글들을 보여줌
-    func searchRelatedPost(query: String) -> AnyPublisher<[PostFindResponse], NetworkError>
+    func searchRelatedPost(query: String, postCount: Int) -> AnyPublisher<[PostFindResponse], NetworkError>
     
     /// postId를 기준으로, 해당 장소와 가장 많이 함께 간 장소를 보여줌
     func searchRelatedLocation(query: String) -> AnyPublisher<[RelatedLocation], NetworkError>
@@ -65,12 +65,12 @@ final class Searcher: SearchUseCase {
         return provider.request(TravelEndPoint.search(query, page))
     }
     
-    func searchPost(query: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
-        return provider.request(PostSearchEndPoint.search(query))
+    func searchPost(query: String, postCount: Int) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
+        return provider.request(PostSearchEndPoint.search(query, postCount))
     }
     
     func searchMockPost(query: String, json: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
-        return provider.mockRequest(PostFindEndPoint.searchPost(query), url: json)
+        return provider.mockRequest(PostFindEndPoint.searchPost(query, 0), url: json)
     }
     
     func fetchHitPost(postCount: Int) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
@@ -89,16 +89,16 @@ final class Searcher: SearchUseCase {
         return provider.mockRequest(UserInfoEndPoint.search(query), url: json)
     }
     
-    func searchPostTitle(query: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
-        return provider.request(PostFindEndPoint.searchPost(query))
+    func searchPostTitle(query: String, postCount: Int) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
+        return provider.request(PostFindEndPoint.searchPost(query, postCount))
     }
     
     func searchAccountWord(query: String) -> AnyPublisher<[UserProfile], MacroNetwork.NetworkError> {
         return provider.request(PostFindEndPoint.searchAccount(query))
     }
     
-    func searchRelatedPost(query: String) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
-        return provider.request(LocationInfoEndPoint.relatedPost(query))
+    func searchRelatedPost(query: String, postCount: Int) -> AnyPublisher<[PostFindResponse], MacroNetwork.NetworkError> {
+        return provider.request(LocationInfoEndPoint.relatedPost(query, postCount))
     }
     
     func searchRelatedLocation(query: String) -> AnyPublisher<[RelatedLocation], MacroNetwork.NetworkError> {

--- a/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
+++ b/iOS/Macro/Macro/Scene/Home/InterfaceAdapters/View/HomeViewController.swift
@@ -17,7 +17,7 @@ final class HomeViewController: TouchableViewController {
     private let inputSubject: PassthroughSubject<HomeViewModel.Input, Never> = .init()
     private let provider = APIProvider(session: URLSession.shared)
     private var cancellables = Set<AnyCancellable>()
-    let postCollectionViewModel = PostCollectionViewModel(posts: [], followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)))
+    let postCollectionViewModel = PostCollectionViewModel( followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)), sceneType: .home)
     
     // MARK: - UI Components
     

--- a/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
@@ -15,7 +15,7 @@ final class LocationInfoViewController: TouchableViewController {
     // MARK: - Properties
     
     let viewModel: LocationInfoViewModel
-    let postCollectionViewModel = PostCollectionViewModel(posts: [], followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)))
+    let postCollectionViewModel = PostCollectionViewModel(followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)), sceneType: .relatedPost)
     private var cancellables = Set<AnyCancellable>()
     private let inputSubject: PassthroughSubject<LocationInfoViewModel.Input, Never> = .init()
     

--- a/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/VIew/LocationInfoViewController.swift
@@ -229,6 +229,8 @@ extension LocationInfoViewController {
         categoryNameLabel.text = locationDetail.categoryName.isEmpty == true ? "-" : locationDetail.categoryName
         categoryGroupLabel.text = locationDetail.categoryGroupName.isEmpty == true ? "-" : "(\(locationDetail.categoryGroupName))"
         phoneLabel.text = locationDetail.phone?.isEmpty == true ? "-" : (locationDetail.phone ?? "-")
+        
+        postCollectionViewModel.query = detail?.id
     }
     
     @objc private func segmentValueChanged(_ sender: UISegmentedControl) {

--- a/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/ViewModel/LocationInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/ViewModel/LocationInfoViewModel.swift
@@ -68,7 +68,7 @@ extension LocationInfoViewModel {
         var placeId = locationDetail.id
         // TODO: 임시로 불러온 값을 확인할 수 있게 지정했음.
         placeId = "7963969"
-        searcher.searchRelatedPost(query: placeId).sink { _ in
+        searcher.searchRelatedPost(query: placeId, postCount: posts.count).sink { _ in
         } receiveValue: { [weak self] response in
             self?.posts = response
             self?.outputSubject.send(.sendRelatedPost(response))

--- a/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/ViewModel/LocationInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/InterfaceAdapters/ViewModel/LocationInfoViewModel.swift
@@ -68,7 +68,7 @@ extension LocationInfoViewModel {
         var placeId = locationDetail.id
         // TODO: 임시로 불러온 값을 확인할 수 있게 지정했음.
         placeId = "7963969"
-        searcher.searchRelatedPost(query: placeId, postCount: posts.count).sink { _ in
+        searcher.searchRelatedPost(query: placeId, postCount: 0).sink { _ in
         } receiveValue: { [weak self] response in
             self?.posts = response
             self?.outputSubject.send(.sendRelatedPost(response))

--- a/iOS/Macro/Macro/Scene/LocationInfo/Network/LocationInfoEndPoint.swift
+++ b/iOS/Macro/Macro/Scene/LocationInfo/Network/LocationInfoEndPoint.swift
@@ -10,7 +10,7 @@ import Foundation
 import MacroNetwork
 
 enum LocationInfoEndPoint {
-    case relatedPost(String)
+    case relatedPost(String, Int)
     case relatedLocation(String)
     
 }
@@ -28,8 +28,9 @@ extension LocationInfoEndPoint: EndPoint {
     
     var parameter: MacroNetwork.HTTPParameter {
         switch self {
-        case .relatedPost(let postId):
-            return .query(["placeId": postId])
+        case let .relatedPost(postId, skip):
+            return .query(["placeId": postId, "skip": "\(skip)"])
+            
         case .relatedLocation(let postId):
             return .query(["placeId": postId])
         }

--- a/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/IntroductionEditView.swift
+++ b/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/IntroductionEditView.swift
@@ -5,9 +5,14 @@
 //  Created by 김나훈 on 11/27/23.
 //
 
+import Combine
 import UIKit
 
 final class IntroductionEditView: UIView {
+    
+    // MARK: - Properties
+    
+    private var cancellables = Set<AnyCancellable>()
     
     // MARK: - UI Components
     
@@ -65,10 +70,24 @@ extension IntroductionEditView {
             introductionTextView.heightAnchor.constraint(equalToConstant: Metrics.textFieldHeight)
         ])
     }
+    
     private func setUpLayout() {
         setTranslatesAutoresizingMaskIntoConstraints()
         addsubviews()
         setLayoutConstraints()
+    }
+}
+
+// MARK: - Methods
+
+extension IntroductionEditView {
+    func configure(with viewModel: MyPageViewModel) {
+        viewModel.$myInfo
+            .receive(on: RunLoop.main)
+            .sink { [weak self] myInfo in
+                self?.introductionTextView.text = myInfo.introduce
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyInfoViewController.swift
@@ -19,7 +19,7 @@ final class MyInfoViewController: UIViewController {
     
     // MARK: - UI Components
     
-    lazy var guideLabel: UILabel = {
+    private lazy var guideLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.appFont(.baeEunLargeTitle)
         label.text = viewModel.information[selectedIndex]
@@ -29,14 +29,12 @@ final class MyInfoViewController: UIViewController {
     private lazy var nameEditView: NameEditView = {
         let view = NameEditView()
         view.optionLabel.text = viewModel.information[selectedIndex]
-        view.nameTextField.text = viewModel.myInfo.name
         return view
     }()
     
     private lazy var introductionEditView: IntroductionEditView = {
         let view = IntroductionEditView()
         view.optionLabel.text = viewModel.information[selectedIndex]
-        view.introductionTextView.text = viewModel.myInfo.introduce
         return view
     }()
     
@@ -56,6 +54,8 @@ final class MyInfoViewController: UIViewController {
         setUpLayout()
         saveButton.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
         bind()
+        introductionEditView.configure(with: viewModel)
+        nameEditView.configure(with: viewModel)
         hideKeyboardWhenTappedAround()
     }
     
@@ -139,8 +139,10 @@ extension MyInfoViewController {
         let outputSubject = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
         outputSubject.receive(on: RunLoop.main).sink { [weak self] output in
             switch output {
-            case .dissMissView: self?.dissMissView()
-            case let .showAlert(failError): self?.showAlert(failError)
+            case .dissMissView:
+                self?.dissMissView()
+            case let .showAlert(failError): 
+                self?.showAlert(failError)
             default: break
             }
         }.store(in: &cancellables)
@@ -151,6 +153,7 @@ extension MyInfoViewController {
 // MARK: - Methods
 
 extension MyInfoViewController {
+    
     private func dissMissView() {
         self.dismiss(animated: true, completion: nil)
     }

--- a/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyPageHeaderView.swift
+++ b/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyPageHeaderView.swift
@@ -77,7 +77,7 @@ private extension MyPageHeaderView {
 
 extension MyPageHeaderView {
     
-    func configure(userProfile: UserProfile) {
+    func configure(userProfile: UserProfile) { 
         if let url = userProfile.imageUrl {
             loadImage(profileImageStringURL: url) { image in
                 DispatchQueue.main.async { [self] in

--- a/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyPageViewController.swift
+++ b/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/MyPageViewController.swift
@@ -266,7 +266,6 @@ extension MyPageViewController: UITableViewDelegate, UITableViewDataSource {
         
         if indexPath.section == 1 && (indexPath.row == 0 || indexPath.row == 2) {
             let myInfoVC = MyInfoViewController(viewModel: viewModel, selectedIndex: indexPath.row)
-            
             if #available(iOS 15.0, *) {
                 myInfoVC.sheetPresentationController?.detents = [.large()]
                 myInfoVC.sheetPresentationController?.prefersGrabberVisible = true

--- a/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/NameEditView.swift
+++ b/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/View/NameEditView.swift
@@ -1,6 +1,10 @@
+import Combine
 import UIKit
 
 final class NameEditView: UIView {
+    
+    // MARK: - Properties
+    private var cancellables = Set<AnyCancellable>()
     
     // MARK: - UI Components
     
@@ -62,6 +66,21 @@ extension NameEditView {
         setTranslatesAutoresizingMaskIntoConstraints()
         addsubviews()
         setLayoutConstraints()
+    }
+    
+}
+
+// MARK: - Methods
+
+extension NameEditView {
+    
+    func configure(with viewModel: MyPageViewModel) {
+        viewModel.$myInfo
+            .receive(on: RunLoop.main)
+            .sink { [weak self] myInfo in
+                self?.nameTextField.text = myInfo.name
+            }
+            .store(in: &cancellables)
     }
     
 }

--- a/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/ViewModel/MyPageViewModel.swift
+++ b/iOS/Macro/Macro/Scene/MyPage/InterfaceAdapters/ViewModel/MyPageViewModel.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-class MyPageViewModel: ViewModelProtocol {
+final class MyPageViewModel: ViewModelProtocol {
     
     // MARK: - Properties
     
@@ -69,7 +69,6 @@ extension MyPageViewModel {
                 switch input {
                 case let .completeButtonTapped(cellIndex, query):
                     self?.checkValidInput(cellIndex, query)
-                    self?.getMyUserData(self?.email ?? "")
                 case let .getMyUserData(email):
                     self?.getMyUserData(email)
                 case let .selectImage(data):
@@ -132,7 +131,14 @@ extension MyPageViewModel {
     private func modifyInformation(_ cellIndex: Int, _ query: String) {
         patcher.patchUser(cellIndex: cellIndex, query: query).sink { _ in
         } receiveValue: { [weak self] _ in
-            self?.outputSubject.send(.patchCompleted(cellIndex, query))
+            switch cellIndex {
+            case 0:
+                self?.myInfo.name = query
+            case 1:
+                self?.myInfo.imageUrl = query
+            default: self?.myInfo.introduce = query
+            }
+            self?.getMyUserData(self?.email ?? "")
         }.store(in: &cancellables)
     }
     
@@ -142,7 +148,6 @@ extension MyPageViewModel {
         case 0: result = self.comfirmer.confirmNickName(text: query)
         default: result = self.comfirmer.confirmIntroduce(text: query)
         }
-        
         switch result {
         case .success:
             modifyInformation(cellIndex, query)

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
@@ -16,7 +16,7 @@ final class SearchViewController: TouchableViewController {
     let viewModel: SearchViewModel
     private var cancellables = Set<AnyCancellable>()
     private let inputSubject: PassthroughSubject<SearchViewModel.Input, Never> = .init()
-    let postCollectionViewModel = PostCollectionViewModel(posts: [], followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)))
+    let postCollectionViewModel = PostCollectionViewModel(followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)), sceneType: .searchPostTitle)
     
     // MARK: - UI Components
     

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
@@ -70,6 +70,7 @@ final class SearchViewController: TouchableViewController {
         userResultCollectionView.postDelegate = self
         searchSegment.addTarget(self, action: #selector(segmentValueChanged(_:)), for: .valueChanged)
         searchBar.addTarget(self, action: #selector(searchBarReturnPressed), for: .editingDidEndOnExit)
+        hideKeyboardWhenTappedAround()
     }
     
     // MARK: Init

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
@@ -160,6 +160,7 @@ extension SearchViewController {
     
     @objc private func searchBarReturnPressed() {
         let text = searchBar.text ?? ""
+        postCollectionViewModel.query = text
         inputSubject.send(.search(text))
     }
     

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/UserResultCell.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/UserResultCell.swift
@@ -21,11 +21,11 @@ final class UserResultCell: UICollectionViewCell {
     
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
-           imageView.contentMode = .scaleAspectFill
-           imageView.clipsToBounds = true
-           imageView.layer.cornerRadius = imageView.frame.width / 2
-           imageView.layer.masksToBounds = true
-           return imageView
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = imageView.frame.width / 2
+        imageView.layer.masksToBounds = true
+        return imageView
     }()
     
     override init(frame: CGRect) {
@@ -80,18 +80,20 @@ extension UserResultCell {
     
     func configure(with profile: UserProfile) {
         userNameLabel.text = profile.name
-        guard let imageUrl = profile.imageUrl else { 
-            self.profileImageView.image = nil
+        guard let imageUrl = profile.imageUrl else {
+            self.profileImageView.image = UIImage.appImage(.ProfileDefaultImage)
             return
         }
         if let url = URL(string: imageUrl) {
-            URLSession.shared.dataTask(with: url) { (data, _, _) in
+            URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in
                 if let data = data, let image = UIImage(data: data) {
                     DispatchQueue.main.async {
-                        self.profileImageView.image = image
+                        self?.profileImageView.image = image
                     }
                 } else {
-                    self.profileImageView.image = nil
+                    DispatchQueue.main.async {
+                        self?.profileImageView.image = UIImage.appImage(.ProfileDefaultImage)
+                    }
                 }
             }.resume()
         }

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
@@ -83,7 +83,7 @@ extension SearchViewModel {
     }
     
     private func searchPost(text: String) {
-        searcher.searchPostTitle(query: text)
+        searcher.searchPostTitle(query: text, postCount: posts.count)
             .sink { completion in
                 if case let .failure(error) = completion {
                     Log.make().error("\(error)")

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
@@ -83,7 +83,7 @@ extension SearchViewModel {
     }
     
     private func searchPost(text: String) {
-        searcher.searchPostTitle(query: text, postCount: posts.count)
+        searcher.searchPostTitle(query: text, postCount: 0)
             .sink { completion in
                 if case let .failure(error) = completion {
                     Log.make().error("\(error)")

--- a/iOS/Macro/Macro/Scene/Search/Network/PostFindEndPoint.swift
+++ b/iOS/Macro/Macro/Scene/Search/Network/PostFindEndPoint.swift
@@ -9,7 +9,7 @@ import Foundation
 import MacroNetwork
 
 enum PostFindEndPoint {
-    case searchPost(String)
+    case searchPost(String, Int)
     case searchAccount(String)
 }
 
@@ -26,8 +26,8 @@ extension PostFindEndPoint: EndPoint {
     
     var parameter: MacroNetwork.HTTPParameter {
         switch self {
-        case let .searchPost(text):
-            return .query(["title": text])
+        case let .searchPost(text, skip):
+            return .query(["title": text, "skip": "\(skip)"])
         case let .searchAccount(text):
             return .query(["name": text])
         }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
@@ -69,8 +69,6 @@ final class TravelViewController: TabViewController,
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
-        locationManager.requestWhenInUseAuthorization()
         setUpLayouts()
         setUpConstraints()
         setupRouteTableViewController()
@@ -79,9 +77,7 @@ final class TravelViewController: TabViewController,
         searchBar.addTarget(self, action: #selector(searchBarReturnPressed), for: .editingDidEndOnExit)
         locationManager.delegate = self
         mapView.delegate = self
-        locationManager.requestWhenInUseAuthorization()
         locationManager.startUpdatingLocation()
-        
     }
     
     override func viewWillLayoutSubviews() {

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -195,7 +195,7 @@ extension TravelViewModel {
     }
     
     func isPinned(_ locationDetail: LocationDetail) -> Bool {
-        return savedRoute.pinnedPlaces.contains(where: { $0.placeName == locationDetail.placeName })
+        return savedRoute.pinnedPlaces.contains(where: { $0.id == locationDetail.id })
     }
     
 }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoProfileView.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoProfileView.swift
@@ -104,9 +104,23 @@ extension UserInfoProfileView {
 
 extension UserInfoProfileView {
     func configure(item: UserProfile) {
-        // TODO: nil 일 경우 default 이미지
-        loadImage(profileImageStringURL: item.imageUrl ?? "") { image in
-            self.userProfileImageView.image = image
+     
+        guard let imageUrl = item.imageUrl else {
+            self.userProfileImageView.image = UIImage.appImage(.ProfileDefaultImage)
+            return
+        }
+        if let url = URL(string: imageUrl) {
+            URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in
+                if let data = data, let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self?.userProfileImageView.image = image
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        self?.userProfileImageView.image = UIImage.appImage(.ProfileDefaultImage)
+                    }
+                }
+            }.resume()
         }
         
         self.userIntroduceLabel.text = item.introduce
@@ -115,19 +129,6 @@ extension UserInfoProfileView {
     
     func updateFollow(item: UserProfile) {
         self.userFollowerCountLabel.text = "\(item.followersNum)"
-    }
-    
-    func loadImage(profileImageStringURL: String, completion: @escaping (UIImage?) -> Void) {
-        guard let url = URL(string: profileImageStringURL) else { return }
-        URLSession.shared.dataTask(with: url) { data, _, _ in
-            if let data = data, let image = UIImage(data: data) {
-                DispatchQueue.main.async {
-                    completion(image)
-                }
-            } else {
-                completion(nil)
-            }
-        }.resume()
     }
     
 }

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
@@ -14,7 +14,7 @@ final class UserInfoViewController: TouchableViewController {
     // MARK: - Properties
     
     private let viewModel: UserInfoViewModel
-    let postCollectionViewModel = PostCollectionViewModel(posts: [], followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)))
+    let postCollectionViewModel = PostCollectionViewModel(followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)), sceneType: .userInfoPost)
     private let inputSubject: PassthroughSubject<UserInfoViewModel.Input, Never> = .init()
     private var cancellables = Set<AnyCancellable>()
     

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/View/UserInfoViewController.swift
@@ -31,13 +31,15 @@ final class UserInfoViewController: TouchableViewController {
     }()
     
     // MARK: - Life Cycle
+    
     override func viewDidLoad() {
+        super.viewDidLoad()
         self.view.backgroundColor = UIColor.appColor(.blue1)
         bind()
         inputSubject.send(.searchUserProfile(email: viewModel.searchUserEmail))
         setUpLayout()
-        super.viewDidLoad()
         postCollectionView.postDelegate = self
+        print(1)
     }
     
     // MARK: - Init
@@ -45,6 +47,7 @@ final class UserInfoViewController: TouchableViewController {
     init(viewModel: UserInfoViewModel, userInfo: String) {
         self.viewModel = viewModel
         viewModel.searchUserEmail = userInfo
+        postCollectionViewModel.query = userInfo
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/InterfaceAdapters/ViewModel/UserInfoViewModel.swift
@@ -99,7 +99,7 @@ extension UserInfoViewModel {
     }
     
     private func searchPost() {
-        searcher.searchPost(query: searchUserEmail).sink { _ in
+        searcher.searchPost(query: searchUserEmail, postCount: posts.count).sink { _ in
         } receiveValue: { [weak self] response in
             self?.posts = response
             self?.outputSubject.send(.updateUserPost(response))

--- a/iOS/Macro/Macro/Scene/UserInfo/Network/PostSearchEndPoint.swift
+++ b/iOS/Macro/Macro/Scene/UserInfo/Network/PostSearchEndPoint.swift
@@ -9,7 +9,7 @@ import Foundation
 import MacroNetwork
 
 enum PostSearchEndPoint {
-    case search(String)
+    case search(String, Int)
 }
 
 extension PostSearchEndPoint: EndPoint {
@@ -25,8 +25,8 @@ extension PostSearchEndPoint: EndPoint {
     
     var parameter: MacroNetwork.HTTPParameter {
         switch self {
-        case let .search(email):
-            return .query(["email": email])
+        case let .search(email, skip):
+            return .query(["email": email, "skip": "\(skip)"])
         }
     }
     

--- a/iOS/Macro/Macro/Util/UIView+.swift
+++ b/iOS/Macro/Macro/Util/UIView+.swift
@@ -1,0 +1,17 @@
+//
+//  UIView+.swift
+//  Macro
+//
+//  Created by 김나훈 on 12/7/23.
+//
+
+import UIKit
+
+extension UIView {
+    func isValidUrl(urlString: String) -> Bool {
+        if let url = URL(string: urlString) {
+            return UIApplication.shared.canOpenURL(url)
+        }
+        return false
+    }
+}

--- a/iOS/Macro/Macro/Util/UIViewController+.swift
+++ b/iOS/Macro/Macro/Util/UIViewController+.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-// 키보드 숨기기
 extension UIViewController {
     func hideKeyboardWhenTappedAround() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))


### PR DESCRIPTION
## 개요 📖

컬렉션뷰 버그 픽스

## 설명 📄

1. 컬렉션뷰 셀에서 이미지를 2번씩 처리하던것 개선
2. 스크롤해서 내릴때, 다음 글을 불러오는 것을 페이지마다 다르게 개선
3. 이미지 로딩 실패시 기본 이미지를 표시하도록 개선
4. 내 이름 수정, 자기소개 수정이 될때도 있고 안될 때도 있던 버그 수정
5. travel page에서 장소를 핀한 것에서, 중복된 이름의 장소도 pin 된 버그 수정
6. 최초 위치 권한을 물어보는 것을 AppDelegate로 변경



## Close Issues 🔒 (닫을 Issue)


Close #213 


공통 체크 리스트
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 작업에 맞는 label을 추가했는지 확인
- [x] 컨벤션 지켰는지 확인

iOS 체크 리스트
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] 다양한 디바이스에 레이아웃이 대응되는지 확인
  - [x] iPhone SE
  - [x] iPhone 15
  - [x] iPhone 15 Pro Max

