### PR TITLE
[enhancement][#255] Refresh 실패 시 로그인 화면으로 넘어가도록 설정

### DIFF
--- a/iOS/Macro/Macro/App/SceneDelegate.swift
+++ b/iOS/Macro/Macro/App/SceneDelegate.swift
@@ -41,11 +41,14 @@ extension SceneDelegate {
         
         switch loginState {
         case .loggedIn:
-            TokenManager.refreshToken(cancellables: &cancellables)
-            let tabbarViewModel = TabBarViewModel()
-            let tabbarViewController = TabBarViewController(viewModel: tabbarViewModel)
-            self.navigationController = UINavigationController(rootViewController: tabbarViewController)
-            self.window?.rootViewController = self.navigationController
+            if TokenManager.refreshToken(cancellables: &cancellables) {
+                let tabbarViewModel = TabBarViewModel()
+                let tabbarViewController = TabBarViewController(viewModel: tabbarViewModel)
+                self.navigationController = UINavigationController(rootViewController: tabbarViewController)
+                self.window?.rootViewController = self.navigationController
+            } else {
+                loginStateSubject.value = .loggedOut
+            }
         case .loggedOut:
             let provider = APIProvider(session: URLSession.shared)
             let repository = LoginRepository(provider: provider)


### PR DESCRIPTION
## 개요 📖

#255 Refresh 실패 시 로그인 화면으로 넘어가도록 설정

## 설명 📄

기존 로직에서 Login화면과 메인 화면을 분기 처리하는 기준은 accessToken의 기한이 만료가 되었는가 였습니다.
그래서 이것을 RefreshToken으로 한번 더 분기 처리해서 안전하게 처리할 수 있도록 수정하고자 했습니다.


