### PR TITLE
[feat][#272] 여행 경로가 없을 때, 여행페이지로 이동하는 UI, 로직, profile Image radius 오류 수정

### DIFF
--- a/iOS/Macro/Macro.xcodeproj/project.pbxproj
+++ b/iOS/Macro/Macro.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		BA7954722B2509CA00C4BAC8 /* ReportEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7954712B2509CA00C4BAC8 /* ReportEndPoint.swift */; };
 		BA7954742B2510C400C4BAC8 /* ReportUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7954732B2510C400C4BAC8 /* ReportUseCase.swift */; };
 		BA7954762B2512B300C4BAC8 /* ReportResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7954752B2512B300C4BAC8 /* ReportResponse.swift */; };
+		BA7954782B2520C400C4BAC8 /* TabbarType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7954772B2520C400C4BAC8 /* TabbarType.swift */; };
 		BA8742F02B204C2800DBDE03 /* CustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8742EF2B204C2800DBDE03 /* CustomAlertViewController.swift */; };
 		BA8742F32B204CA800DBDE03 /* CancelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8742F22B204CA800DBDE03 /* CancelAction.swift */; };
 		BA8742F52B204D0B00DBDE03 /* AlertBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8742F42B204D0B00DBDE03 /* AlertBuilder.swift */; };
@@ -269,6 +270,7 @@
 		BA7954712B2509CA00C4BAC8 /* ReportEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportEndPoint.swift; sourceTree = "<group>"; };
 		BA7954732B2510C400C4BAC8 /* ReportUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportUseCase.swift; sourceTree = "<group>"; };
 		BA7954752B2512B300C4BAC8 /* ReportResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportResponse.swift; sourceTree = "<group>"; };
+		BA7954772B2520C400C4BAC8 /* TabbarType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarType.swift; sourceTree = "<group>"; };
 		BA8742EF2B204C2800DBDE03 /* CustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertViewController.swift; sourceTree = "<group>"; };
 		BA8742F22B204CA800DBDE03 /* CancelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelAction.swift; sourceTree = "<group>"; };
 		BA8742F42B204D0B00DBDE03 /* AlertBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertBuilder.swift; sourceTree = "<group>"; };
@@ -854,6 +856,7 @@
 			children = (
 				BA6C6DEA2B05FFC500563B22 /* TabLocation.swift */,
 				BA6C6DEB2B05FFC500563B22 /* TabComponent.swift */,
+				BA7954772B2520C400C4BAC8 /* TabbarType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1570,6 +1573,7 @@
 				BA6C6DF32B05FFC500563B22 /* CAGradientLayer+.swift in Sources */,
 				BA6C6DFE2B05FFC500563B22 /* TabBarOpacityView.swift in Sources */,
 				D2CAA5E32B1F11B600E825BA /* FollowType.swift in Sources */,
+				BA7954782B2520C400C4BAC8 /* TabbarType.swift in Sources */,
 				D2CAA5DB2B1E151800E825BA /* RelatedLocationCell.swift in Sources */,
 				BA00A0892B1732E6007F7BB9 /* MapCollectionViewCellHeaderView.swift in Sources */,
 				BAB24EEC2B16DE55000991A1 /* MapCollectionViewCell.swift in Sources */,

--- a/iOS/Macro/Macro/Common/TabBar/Model/TabComponent.swift
+++ b/iOS/Macro/Macro/Common/TabBar/Model/TabComponent.swift
@@ -13,4 +13,5 @@ struct TabComponent {
     let image: UIImage?
     let text: String
     let viewController: UIViewController
+    let type: TabbarType
 }

--- a/iOS/Macro/Macro/Common/TabBar/Model/TabbarType.swift
+++ b/iOS/Macro/Macro/Common/TabBar/Model/TabbarType.swift
@@ -1,0 +1,16 @@
+//
+//  TabbarType.swift
+//  Macro
+//
+//  Created by Byeon jinha on 12/10/23.
+//
+
+import Foundation
+
+enum TabbarType {
+    case home
+    case travel
+    case myPage
+    case search
+    case write
+}

--- a/iOS/Macro/Macro/Common/TabBar/View/TabBarCenterView.swift
+++ b/iOS/Macro/Macro/Common/TabBar/View/TabBarCenterView.swift
@@ -11,7 +11,7 @@ final class TabBarCenterView: UIView, CircularViewProtocol {
     
     let imageView: UIImageView = UIImageView()
     
-    var image: UIImage = UIImage(systemName: "house") ?? UIImage() {
+    var image: UIImage? = UIImage(systemName: "house") {
         didSet {
             setNeedsLayout()
         }
@@ -96,7 +96,7 @@ final class TabBarCenterView: UIView, CircularViewProtocol {
         guard let gradientLayer = imageView.layer.sublayers?.compactMap({ $0 as? CAGradientLayer }).first,
               let mask = gradientLayer.mask else { return }
         
-        mask.contents = image.cgImage
+        mask.contents = image?.cgImage
     }
 }
 

--- a/iOS/Macro/Macro/Common/TabBar/ViewModel/TabBarViewModel.swift
+++ b/iOS/Macro/Macro/Common/TabBar/ViewModel/TabBarViewModel.swift
@@ -11,7 +11,21 @@ import MacroNetwork
 import Network
 import UIKit
 
-final class TabBarViewModel {
+final class TabBarViewModel: ViewModelProtocol {
+    
+    // MARK: - Input
+    
+    enum Input {
+        case changeTap(TabbarType)
+    }
+    
+    // MARK: - Output
+    
+    enum Output {
+        case changeTap(TabbarType)
+    }
+
+    // MARK: - Properties
     let tabComponentArray = CurrentValueSubject<[TabComponent], Never>([])
     var currentTabComponent: CurrentValueSubject<TabComponent, Never>
     var radius: CGFloat = 90
@@ -20,36 +34,50 @@ final class TabBarViewModel {
     var isTabBarActive: Bool = false
     var animationStep: Int = 0
     
+    private var cancellables = Set<AnyCancellable>()
+    private let outputSubject = PassthroughSubject<Output, Never>()
+    
     init() {
         let provider = APIProvider(session: URLSession.shared)
-        let searchViewModel = SearchViewModel(searcher: Searcher(provider: provider), patcher: Patcher(provider: provider))
-        let homeViewModel = HomeViewModel(postSearcher: Searcher(provider: provider), followFeature: FollowFeature(provider: provider), patcher: Patcher(provider: provider))
+        let searchViewModel = SearchViewModel(searcher: Searcher(provider: provider), 
+                                              patcher: Patcher(provider: provider))
+        
+        let homeViewModel = HomeViewModel(postSearcher: Searcher(provider: provider),
+                                          followFeature: FollowFeature(provider: provider),
+                                          patcher: Patcher(provider: provider))
+        
         let routeViewModel = RouteViewModel()
         let travelViewModel = TravelViewModel(
             locationSearcher: Searcher(provider: provider),
             pinnedPlaceManager: PinnedPlaceManager(provider: provider))
-        let myPageViewModel = MyPageViewModel(patcher: Patcher(provider: provider), 
+        
+        let myPageViewModel = MyPageViewModel(patcher: Patcher(provider: provider),
                                               searcher: Searcher(provider: provider),
                                               confirmer: Confirmer(),
                                               uploader: UploadImage(provider: provider),
                                               revoker: Revoker(provider: provider))
+        
         let setComponentArray = [
         TabComponent(index: 1,
                      image: UIImage.appImage(.magnifyingglass),
                      text: "검색",
-                     viewController: SearchViewController(viewModel: searchViewModel)),
+                     viewController: SearchViewController(viewModel: searchViewModel, tabBarOutputSubject: outputSubject),
+                     type: .search),
         TabComponent(index: 2,
                      image: UIImage.appImage(.personCircle),
                      text: "내 정보",
-                     viewController: MyPageViewController(viewModel: myPageViewModel)),
+                     viewController: MyPageViewController(viewModel: myPageViewModel), 
+                     type: .myPage),
         TabComponent(index: 3,
                      image: UIImage.appImage(.squareAndPencil),
                      text: "기록",
-                     viewController: RouteViewController(viewModel: routeViewModel)),
+                     viewController: RouteViewController(viewModel: routeViewModel, tabBarOutputSubject: outputSubject),
+                     type: .write),
         TabComponent(index: 4,
                      image: UIImage.appImage(.map),
                      text: "여행",
-                     viewController: TravelViewController(viewModel: travelViewModel))
+                     viewController: TravelViewController(viewModel: travelViewModel), 
+                     type: .travel)
         ]
         
         self.tabComponentArray.value = setComponentArray
@@ -57,12 +85,29 @@ final class TabBarViewModel {
             TabComponent(index: 0,
                          image: UIImage.appImage(.house),
                          text: "홈",
-                         viewController: HomeViewController(viewModel: homeViewModel)))
-        setTabComponetArray()
+                         viewController: HomeViewController(viewModel: homeViewModel),
+                         type: .home))
     }
     
-    // MARK: - Method
+}
+
+// MARK: - Methods
+
+extension TabBarViewModel {
     
-    private func setTabComponetArray() {
+    func transform(with input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input.sink { [weak self] input in
+            switch input {
+            case let .changeTap(tabbarType):
+                self?.changeTap(tabbarType)
+            }
+        }.store(in: &cancellables)
+        
+        return outputSubject.eraseToAnyPublisher()
     }
+    
+    func changeTap(_ tabbarType: TabbarType) {
+        outputSubject.send(.changeTap(tabbarType))
+    }
+    
 }

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostProfileView.swift
@@ -199,6 +199,7 @@ extension PostProfileView {
 
     private func setProfileImage(_ image: UIImage?) {
         profileImageView.image = image
+        profileImageView.layer.cornerRadius = 18
     }
     
     func resetContents() {

--- a/iOS/Macro/Macro/Scene/Route/InterfaceAdapters/ViewModel/RouteViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Route/InterfaceAdapters/ViewModel/RouteViewModel.swift
@@ -12,7 +12,11 @@ import MacroNetwork
 class RouteViewModel: ViewModelProtocol, MapCollectionViewProtocol {
 
     // MARK: - Properties
-    var travels: [TravelInfo] = []
+    var travels: [TravelInfo] = [] {
+        didSet {
+            outputSubject.send(.changeInnerView(travels.isEmpty))
+        }
+    }
     private var cancellables = Set<AnyCancellable>()
     private let outputSubject = PassthroughSubject<Output, Never>()
     
@@ -26,6 +30,8 @@ class RouteViewModel: ViewModelProtocol, MapCollectionViewProtocol {
     enum Output {
         case deleteTravel(String)
         case navigateToWriteView(WriteViewModel)
+        case transView(TabbarType)
+        case changeInnerView(Bool)
     }
 }
 

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/View/SearchViewController.swift
@@ -17,6 +17,7 @@ final class SearchViewController: TouchableViewController {
     private var cancellables = Set<AnyCancellable>()
     private let inputSubject: PassthroughSubject<SearchViewModel.Input, Never> = .init()
     let postCollectionViewModel = PostCollectionViewModel(followFeature: FollowFeature(provider: APIProvider(session: URLSession.shared)), patcher: Patcher(provider: APIProvider(session: URLSession.shared)), postSearcher: Searcher(provider: APIProvider(session: URLSession.shared)), sceneType: .searchPostTitle)
+    private var tabBarOutputSubject: PassthroughSubject<TabBarViewModel.Output, Never>
     
     // MARK: - UI Components
     
@@ -75,8 +76,9 @@ final class SearchViewController: TouchableViewController {
     }
     
     // MARK: Init
-    init(viewModel: SearchViewModel) {
+    init(viewModel: SearchViewModel, tabBarOutputSubject: PassthroughSubject<TabBarViewModel.Output, Never>) {
         self.viewModel = viewModel
+        self.tabBarOutputSubject = tabBarOutputSubject
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -143,6 +145,8 @@ extension SearchViewController {
                 self?.updatePostSearchResult(result)
             case let .updateUserSearchResult(result):
                 self?.updateUserSearchResult(result)
+            case let .transView(destinationViewType):
+                self?.transView(destinationViewType)
             }
         }.store(in: &cancellables)
         
@@ -177,6 +181,9 @@ extension SearchViewController {
         userResultCollectionView.reloadData()
     }
     
+    func transView(_ changeTabbarType: TabbarType) {
+        tabBarOutputSubject.send(.changeTap(changeTabbarType))
+    }
 }
 
 // MARK: - LayoutMetrics

--- a/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Search/InterfaceAdapters/ViewModel/SearchViewModel.swift
@@ -40,6 +40,7 @@ final class SearchViewModel: ViewModelProtocol {
     enum Output {
         case updatePostSearchResult([PostFindResponse])
         case updateUserSearchResult([UserProfile])
+        case transView(TabbarType)
     }
     
 }


### PR DESCRIPTION
## 개요 📖

- #272
- 여행 경로가 없을 때, 여행페이지로 이동하는 UI, 로직, profile Image radius 오류 수정

## 설명 📄

- profile Image radius 가 bounds가 잡히기 전에 radius를 줘서 변하지 않는 이슈가 있어 해결했어요.
- 피드백 대로 여행 루트가 없을 때, 여행하기로 바로 갈 수 있도록 했습니다.
- 

## 고민거리 🤔 (Optional) - 의견 받고싶은 부분 있으면 적어두기

### Q. 고민1
뷰컨이 자기 자신의 타입을 알고 있는데, 나훈님과 얘기하면서 자기 타입을 들고 있는 것이 좋지 않은 걸 알았어요. 차후 수정이 필요합니다. :)
아직 뷰를 미쳐 다 그리지 못해 빨간 화면으로만 띄워주고 있어요. 주말까지 마무리하겠습니다. 👍 

## Close Issues

Close #272
