### PR TITLE
[enhancement][#251] 상세 페이지의 변경 내용을 CollectionView에 반영

### DIFF
--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
@@ -15,6 +15,7 @@ final class PostCollectionView: UICollectionView {
     let viewModel: PostCollectionViewModel
     private var cancellables = Set<AnyCancellable>()
     weak var postDelegate: PostCollectionViewDelegate?
+    var readViewDisappear: PassthroughSubject<LikePostResponse, Never> = .init()
     private let inputSubject: PassthroughSubject<PostCollectionViewModel.Input, Never> = .init()
     private let postRefreshControl: UIRefreshControl = UIRefreshControl()
     
@@ -100,9 +101,10 @@ extension PostCollectionView: UICollectionViewDataSource {
         else { return UICollectionViewCell() }
         
         cell.delegate = postDelegate
+        cell.readViewDisappear = self.readViewDisappear
         if !viewModel.posts.isEmpty {
             let item = viewModel.posts[indexPath.row]
-            cell.configure(item: item, viewModel: viewModel, indexPath: indexPath)
+            cell.configure(item: item, viewModel: viewModel, indexPath: indexPath, readViewDisappear: self.readViewDisappear)
         }
         
         return cell

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionViewCell.swift
@@ -5,6 +5,7 @@
 //  Created by Byeon jinha on 11/16/23.
 //
 
+import Combine
 import UIKit
 
 final class PostCollectionViewCell: UICollectionViewCell {
@@ -13,6 +14,7 @@ final class PostCollectionViewCell: UICollectionViewCell {
     
     let identifier = "PostCollectionViewCell"
     var viewModel: PostCollectionViewModel?
+    var readViewDisappear: PassthroughSubject<LikePostResponse, Never> = .init()
     weak var delegate: PostCollectionViewDelegate?
     
     // MARK: - UI Components
@@ -24,6 +26,7 @@ final class PostCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         self.postContentView = PostContentView()
+        self.postContentView.readViewDisappear = self.readViewDisappear
         self.postProfileView = PostProfileView()
         super.init(frame: frame)
         
@@ -77,9 +80,10 @@ extension PostCollectionViewCell {
 
 extension PostCollectionViewCell {
     
-    func configure(item: PostFindResponse, viewModel: PostCollectionViewModel, indexPath: IndexPath) {
+    func configure(item: PostFindResponse, viewModel: PostCollectionViewModel, indexPath: IndexPath, readViewDisappear: PassthroughSubject<LikePostResponse, Never>) {
         self.viewModel = viewModel
-        postContentView.configure(item: item, viewModel: viewModel)
+        self.readViewDisappear = readViewDisappear
+        postContentView.configure(item: item, viewModel: viewModel, readViewDisappear: self.readViewDisappear)
         postProfileView.configure(item: item, viewModel: viewModel)
         postContentView.setLayout()
         postProfileView.setLayout()

--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostContentView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostContentView.swift
@@ -17,6 +17,7 @@ final class PostContentView: UIView {
     var viewModel: PostCollectionViewModel?
     private let provider = APIProvider(session: URLSession.shared)
     private let inputSubject: PassthroughSubject<PostCollectionViewModel.Input, Never> = .init()
+    var readViewDisappear: PassthroughSubject<LikePostResponse, Never> = .init()
     weak var delegate: PostCollectionViewDelegate?
     var postId: Int?
     
@@ -69,7 +70,7 @@ final class PostContentView: UIView {
         let provider = APIProvider(session: URLSession.shared)
         let readuseCase = ReadPostUseCase(provider: provider)
         let readViewModel = ReadViewModel(useCase: readuseCase, postId: postId, pathcher: Patcher(provider: APIProvider(session: URLSession.shared)), reporter: Reporter(provider: provider))
-        let readViewController = ReadViewController(viewModel: readViewModel)
+        let readViewController = ReadViewController(viewModel: readViewModel, readViewDisappear: readViewDisappear)
         delegate?.didTapContent(viewController: readViewController)
         
         inputSubject.send(.increaseView(postId))
@@ -135,8 +136,9 @@ extension PostContentView {
         addTapGesture()
     }
     
-    func configure(item: PostFindResponse, viewModel: PostCollectionViewModel?) {
+    func configure(item: PostFindResponse, viewModel: PostCollectionViewModel?, readViewDisappear: PassthroughSubject<LikePostResponse, Never>) {
         self.viewModel = viewModel
+        self.readViewDisappear = readViewDisappear
         guard let viewModel = self.viewModel else { return }
         
         if let imageUrl = item.imageUrl, isValidUrl(urlString: imageUrl) {

--- a/iOS/Macro/Macro/Scene/Read/InterfaceAdapters/ViewModel/ReadViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Read/InterfaceAdapters/ViewModel/ReadViewModel.swift
@@ -23,6 +23,7 @@ final class ReadViewModel: ViewModelProtocol, CarouselViewProtocol {
     private let useCase: ReadPostUseCaseProtocol
     private let reporter: ReportUseCase
     private let pathcher: PatchUseCase
+    private var likeInfo: LikePostResponse?
     private let outputSubject = PassthroughSubject<Output, Never>()
     private let postId: Int
     private var userEmail: String?
@@ -46,6 +47,7 @@ final class ReadViewModel: ViewModelProtocol, CarouselViewProtocol {
         case searchUser
         case likeImageTap
         case reportPost(String, String, String)
+        case didDisappear
     }
     
     // MARK: - Output
@@ -55,6 +57,7 @@ final class ReadViewModel: ViewModelProtocol, CarouselViewProtocol {
         case navigateToProfileView(String)
         case updatePageIndex(Int)
         case updatePostLike(LikePostResponse)
+        case updatePostCollection(LikePostResponse?)
     }
 }
 
@@ -74,6 +77,8 @@ extension ReadViewModel {
                     self?.like()
                 case let .reportPost(postId, title, description):
                     self?.reportPost(postId: postId, title: title, description: description)
+                case .didDisappear:
+                    self?.outputSubject.send(.updatePostCollection(self?.likeInfo))
                 }
             }
             .store(in: &cancellables)
@@ -101,6 +106,7 @@ extension ReadViewModel {
         pathcher.patchPostLike(postId: postId).sink { _ in
         } receiveValue: { [weak self] likePostResponse in
             guard likePostResponse.postId == self?.postId else { return }
+            self?.likeInfo = likePostResponse
             self?.outputSubject.send(.updatePostLike(likePostResponse))
         }.store(in: &cancellables)
     }


### PR DESCRIPTION
## 개요 📖

#251 상세 페이지의 변경 내용을 CollectionView에 반영

## 설명 📄

Subject를 생성 후 HomeViewController에서 연결해줬습니다.

## 고민거리 🤔 (Optional) - 의견 받고싶은 부분 있으면 적어두기

### Q. 너무 많이 연결된 Subject

해당 View까지의 Depth가 있어서
이를 연결하기 위해서는 너무 많은 Subject가 연결되는 느낌이라 이 부분이 조금 걱정됩니다.

## 스크린샷 📷

![Simulator Screen Recording - iPhone 15 - 2023-12-11 at 02 32 28](https://github.com/boostcampwm2023/iOS03-Macro/assets/37203016/9401f31e-ed4e-43d9-88ce-1e39d867e342)

## Close Issues 🔒 (닫을 Issue)

Close #251 


